### PR TITLE
fix: resolve 4 code review findings

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -19,7 +19,6 @@ pub fn run() {
       commands::ai::ai_sso_login,
       commands::ai::ai_check_auth,
       commands::ai::ai_chat,
-      commands::ai::ai_list_skills,
     ])
     .setup(|app| {
       if cfg!(debug_assertions) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,7 +59,7 @@ function App() {
 
   return (
     <div className="flex h-screen bg-white dark:bg-gray-900">
-      <Sidebar onOpenChat={() => setChatPanelOpen(true)}>
+      <Sidebar>
         <FileTree />
       </Sidebar>
       <div className="flex-1 flex flex-col min-w-0">

--- a/src/components/AiChatPanel.tsx
+++ b/src/components/AiChatPanel.tsx
@@ -179,7 +179,7 @@ export function AiChatPanel({ onClose }: AiChatPanelProps) {
         <div className="flex items-center gap-2">
           <MessageSquare className="w-4 h-4 text-gray-600 dark:text-gray-400" />
           <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">
-            AI Assistant
+            AI assistant
           </span>
         </div>
         <div className="flex items-center gap-1">

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -35,7 +35,7 @@ export function MarkdownRenderer({ content, onLinkClick }: MarkdownRendererProps
   });
 
   useEffect(() => {
-    if (editor && content) {
+    if (editor) {
       editor.commands.setContent(content);
     }
   }, [content, editor]);

--- a/src/stores/fileTree.ts
+++ b/src/stores/fileTree.ts
@@ -21,7 +21,7 @@ export const useFileTreeStore = create<FileTreeStore>((set, get) => ({
   error: null,
 
   loadTree: async (folderPath: string) => {
-    set({ isLoading: true, error: null });
+    set({ isLoading: true, error: null, selectedFilePath: null });
     try {
       const nodes = await invoke<FileNode[]>("list_files", {
         folderPath,

--- a/tests/unit/MarkdownRenderer.test.tsx
+++ b/tests/unit/MarkdownRenderer.test.tsx
@@ -33,6 +33,12 @@ describe("MarkdownRenderer", () => {
     expect(container.querySelector(".prose")).toBeInTheDocument();
   });
 
+  it("does not leave stale content when content becomes empty", () => {
+    const { rerender } = render(<MarkdownRenderer content="# Hello" />);
+    // Rerendering with empty string should not throw and should call setContent("")
+    expect(() => rerender(<MarkdownRenderer content="" />)).not.toThrow();
+  });
+
   it("accepts onLinkClick prop without error", () => {
     const handleClick = () => {};
     const { container } = render(

--- a/tests/unit/fileTree.test.ts
+++ b/tests/unit/fileTree.test.ts
@@ -47,6 +47,15 @@ describe("useFileTreeStore", () => {
       });
     });
 
+    it("clears selectedFilePath when loading a new tree", async () => {
+      useFileTreeStore.setState({ selectedFilePath: "/docs/old.md" });
+      mockInvoke.mockResolvedValueOnce(mockTree);
+
+      await useFileTreeStore.getState().loadTree("/new-docs");
+
+      expect(useFileTreeStore.getState().selectedFilePath).toBeNull();
+    });
+
     it("sets error on failure", async () => {
       mockInvoke.mockRejectedValueOnce(new Error("Permission denied"));
 


### PR DESCRIPTION
## Summary

- Removes unused `onOpenChat` prop from `<Sidebar>` call in `App.tsx` (TypeScript build error)
- Removes unimplemented `ai_list_skills` from Tauri `invoke_handler` (Rust compile error)
- Calls `setContent` unconditionally in `MarkdownRenderer` so empty files clear stale content
- Resets `selectedFilePath` on `loadTree` so switching folders shows empty state
- Fixes "AI assistant" header casing to sentence case

## Test plan
- [ ] All 160 unit tests pass
- [ ] Open a folder, select a file, switch to a new folder — viewer shows empty state
- [ ] Open an empty file — viewer clears rather than showing previous content

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)