### PR TITLE
fix: show dot-prefixed folders in sidebar file tree

### DIFF
--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -16,10 +16,6 @@ fn is_markdown_file(name: &str) -> bool {
     lower.ends_with(".md") || lower.ends_with(".markdown")
 }
 
-fn is_hidden(name: &str) -> bool {
-    name.starts_with('.')
-}
-
 fn build_tree(dir: &Path) -> Vec<FileNode> {
     let entries = match fs::read_dir(dir) {
         Ok(entries) => entries,
@@ -31,10 +27,6 @@ fn build_tree(dir: &Path) -> Vec<FileNode> {
 
     for entry in entries.flatten() {
         let name = entry.file_name().to_string_lossy().to_string();
-
-        if is_hidden(&name) {
-            continue;
-        }
 
         let path = entry.path();
 
@@ -110,4 +102,28 @@ pub async fn read_file(file_path: String, workspace_path: String) -> Result<Stri
     }
 
     fs::read_to_string(path).map_err(|e| format!("Failed to read file: {}", e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_build_tree_includes_dot_prefixed_folders() {
+        let tmp = TempDir::new().unwrap();
+        let dot_dir = tmp.path().join(".eng-docs");
+        fs::create_dir(&dot_dir).unwrap();
+        fs::write(dot_dir.join("readme.md"), "# Hello").unwrap();
+
+        let tree = build_tree(tmp.path());
+
+        let names: Vec<&str> = tree.iter().map(|n| n.name.as_str()).collect();
+        assert!(
+            names.contains(&".eng-docs"),
+            "Expected .eng-docs in tree, got: {:?}",
+            names
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Removes the `is_hidden()` filter from `build_tree()` in `src-tauri/src/commands/files.rs` so dot-prefixed directories like `.eng-docs` and `.github` appear in the sidebar
- The identical filter in `context.rs` is intentionally kept — it excludes hidden directories from AI context to reduce noise
- Adds a regression test confirming dot-prefixed folders appear in the tree output

## Test Plan

- [ ] Open a workspace containing a dot-prefixed folder (e.g. `.eng-docs`) — it should appear in the sidebar file tree
- [ ] Confirm `.git` also appears (all dot-prefixed entries are now shown)
- [ ] Confirm AI context gathering still excludes dot-prefixed directories (context.rs unchanged)

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)