### PR TITLE
feat: encode design tokens as Tailwind v4 CSS variables

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -1,2 +1,131 @@
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
+
+@theme {
+  /* Typography */
+  --font-ui: "Inter Variable", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-mono: "JetBrains Mono", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+
+  /* UI type scale */
+  --font-size-ui-xs: 11px;
+  --font-size-ui-sm: 12px;
+  --font-size-ui-base: 13px;
+  --font-size-ui-md: 14px;
+  --font-size-ui-lg: 16px;
+
+  /* Document type scale */
+  --font-size-doc-xs: 12px;
+  --font-size-doc-sm: 14px;
+  --font-size-doc-base: 16px;
+  --font-size-doc-h4: 16px;
+  --font-size-doc-h3: 18px;
+  --font-size-doc-h2: 22px;
+  --font-size-doc-h1: 28px;
+
+  /* Spacing */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-10: 40px;
+  --space-14: 56px;
+  --space-20: 80px;
+  --space-32: 128px;
+
+  /* Control dimensions */
+  --height-control-sm: 24px;
+  --height-control-base: 28px;
+  --height-control-lg: 32px;
+  --height-nav-item: 28px;
+  --height-toolbar: 39px;
+  --height-titlebar: 52px;
+  --width-sidebar: 244px;
+  --doc-content-width: 680px;
+
+  /* Padding */
+  --padding-control: 0 12px;
+  --padding-sidebar-item: 0 8px;
+  --padding-toolbar: 0 12px;
+  --padding-panel: 20px;
+  --padding-content: 32px;
+
+  /* Border radius */
+  --radius-sm: 3px;
+  --radius-base: 4px;
+  --radius-md: 6px;
+  --radius-lg: 8px;
+  --radius-xl: 12px;
+  --radius-2xl: 16px;
+  --radius-full: 9999px;
+
+  /* Motion */
+  --duration-instant: 0ms;
+  --duration-fast: 100ms;
+  --duration-normal: 150ms;
+  --duration-slow: 250ms;
+  --ease-default: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-linear: linear;
+
+  /* Accent (mode-independent) */
+  --color-accent: oklch(62% 0.175 230);
+  --color-accent-hover: oklch(66% 0.175 230);
+  --color-accent-subtle: oklch(62% 0.04 230);
+
+  /* State colors (mode-independent) */
+  --color-state-danger: oklch(58% 0.2 25);
+  --color-state-danger-subtle: oklch(58% 0.06 25);
+  --color-state-warning: oklch(72% 0.16 65);
+  --color-state-warning-subtle: oklch(72% 0.05 65);
+  --color-state-success: oklch(65% 0.15 155);
+  --color-state-success-subtle: oklch(65% 0.05 155);
+
+  /* Shadows */
+  --shadow-sm: 0 1px 2px oklch(0% 0 0 / 0.08);
+  --shadow-base: 0 2px 8px oklch(0% 0 0 / 0.12);
+  --shadow-lg: 0 8px 24px oklch(0% 0 0 / 0.16);
+  --shadow-inset-border: inset 0 0 0 1px;
+}
+
+/* Dark mode tokens */
+@layer base {
+  :root {
+    --color-bg-app: oklch(7% 0.01 264);
+    --color-bg-base: oklch(9.5% 0.012 264);
+    --color-bg-subtle: oklch(12% 0.015 264);
+    --color-bg-elevated: oklch(15% 0.018 264);
+    --color-bg-overlay: oklch(18.5% 0.02 264);
+    --color-bg-hover: oklch(21% 0.022 264);
+
+    --color-text-primary: oklch(100% 0 0);
+    --color-text-secondary: oklch(92% 0.008 264);
+    --color-text-tertiary: oklch(65% 0.008 264);
+    --color-text-quaternary: oklch(42% 0.008 264);
+
+    --color-border-subtle: oklch(16% 0.02 264);
+    --color-border-default: oklch(20% 0.022 264);
+    --color-border-strong: oklch(23% 0.022 264);
+  }
+
+  @media (prefers-color-scheme: light) {
+    :root {
+      --color-bg-app: oklch(95% 0.004 264);
+      --color-bg-base: oklch(99% 0.002 264);
+      --color-bg-subtle: oklch(97% 0.003 264);
+      --color-bg-elevated: oklch(100% 0 0);
+      --color-bg-overlay: oklch(98% 0.003 264);
+      --color-bg-hover: oklch(93% 0.005 264);
+
+      --color-text-primary: oklch(18% 0.012 264);
+      --color-text-secondary: oklch(45% 0.01 264);
+      --color-text-tertiary: oklch(62% 0.008 264);
+      --color-text-quaternary: oklch(72% 0.006 264);
+
+      --color-border-subtle: oklch(88% 0.006 264);
+      --color-border-default: oklch(84% 0.007 264);
+      --color-border-strong: oklch(78% 0.008 264);
+    }
+  }
+}


### PR DESCRIPTION
Closes #31

Implements the design token layer in `src/app.css`:
- `@theme {}` block with all mode-independent tokens (typography, spacing, dimensions, radius, motion, accent, state colors, shadows)
- `@layer base` block with dark mode defaults at `:root` and `@media (prefers-color-scheme: light)` override
- CSS-only change; no components modified
- All 211 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)