### PR TITLE
docs: add feature and enhancement specs

### DIFF
--- a/.eng-docs/adrs/adr-009-keyboard-shortcuts.md
+++ b/.eng-docs/adrs/adr-009-keyboard-shortcuts.md
@@ -1,0 +1,68 @@
+# ADR-009: Keyboard shortcuts strategy
+
+## Status
+
+Accepted
+
+## Context
+
+As Episteme grows, users will perform many distinct actions — creating documents, switching modes, sending messages, navigating between files. Without a consistent approach to keyboard shortcuts, these either get added ad hoc (inconsistent modifier keys, no discoverability) or not added at all.
+
+Two constraints matter: the app targets macOS now and Windows later, so shortcuts need platform-aware key bindings (Cmd on macOS, Ctrl on Windows). And shortcuts need to be registered through a central mechanism — not hardcoded at the component level — so they're enumerable, displayable in tooltips and dialogs, and rebindable in the future (see issue #26).
+
+The decision is: what is the app-wide convention for keyboard shortcuts — which actions get them, how are modifier keys chosen, and how are they registered?
+
+## Decision
+
+All user-facing actions should have keyboard shortcuts. Shortcuts are registered through a central Zustand store that maps named actions to key bindings. Components bind to action names through the registry rather than handling raw key events directly. The registry owns platform normalization (Cmd on macOS, Ctrl on Windows), conflict detection, and display strings used in tooltips, menus, and dialogs.
+
+Focus behavior (suppressing shortcuts when a text input has focus) is handled by the registry, not by individual components.
+
+## Consequences
+
+**Positive:**
+- All shortcuts are enumerable: help screens, tooltip labels, and dialog shortcut badges all read from one source
+- Platform normalization (Cmd/Ctrl) lives in one place — no `metaKey` vs `ctrlKey` conditionals scattered across components
+- Conflict detection is possible since every registered shortcut is known to the registry
+- User-assignable shortcuts (issue #26) is a natural extension — rebinding updates the registry, components don't change
+- Consistent with the existing Zustand state management pattern (ADR-003)
+
+**Negative:**
+- More upfront infrastructure than hardcoding — the registry needs to be designed and built before the first shortcut can use it
+- Components must bind to action names through the registry API rather than handling `onKeyDown` directly, which is a new convention the codebase needs to follow consistently
+- Focus behavior edge cases (suppressing shortcuts inside inputs) need to be handled manually rather than relying on a library
+
+## Alternatives considered
+
+### Option A: Hardcode shortcuts per component
+
+Each component defines its own `onKeyDown` handlers and modifier keys inline with no shared infrastructure.
+
+**Pros:**
+- Simple, zero upfront cost
+- Works immediately with no new abstractions
+
+**Cons:**
+- Can't enumerate shortcuts for help screens or tooltip population
+- No conflict detection
+- Platform-specific logic duplicated everywhere
+- Conventions drift across components over time
+
+**Why not chosen:** Makes user-assignable shortcuts (issue #26) effectively impossible and produces an unmaintainable mess as the shortcut surface grows.
+
+### Option C: Library (`react-hotkeys-hook` or similar) + registry on top
+
+Use a battle-tested shortcut library for low-level event handling and modifier normalization, with a thin registry layer on top for action naming and rebinding.
+
+**Pros:**
+- Library handles focus trapping, modifier normalization, and React lifecycle edge cases
+- Less code to write than a full DIY registry
+- Still supports centralized rebinding
+
+**Cons:**
+- Adds a dependency
+- The registry layer still needs to be built regardless
+- Tauri apps have tighter focus control than typical web apps, so library-handled edge cases are less likely to matter
+- Some impedance mismatch between library API and a custom action-name system
+
+**Why not chosen:** The library solves edge cases that are unlikely to arise in a Tauri app, while the registry layer — the majority of the actual work — needs to be built either way. Option B gives full control without the dependency.

--- a/.eng-docs/specs/enhancement-authoring-skill-picker.md
+++ b/.eng-docs/specs/enhancement-authoring-skill-picker.md
@@ -1,0 +1,238 @@
+# Enhancement: Authoring Skill Picker
+
+## Parent feature
+
+`feature-document-authoring.md`
+
+## What
+
+When a user clicks the "New document" button, a small centered dialog titled "Create new" appears. It shows up to three document types plus an "Other" option. The list is populated by the user's recently used types first; any remaining slots are filled by the most frequently created types in the repository. If fewer than three types exist in total, the dialog shows only what's available. Each option displays a static icon, a label, and a keyboard shortcut badge. Selecting a type closes the dialog, sets the active skill, and opens the chat panel ready to begin the guided authoring session. Selecting "Other" opens the chat panel in authoring mode without a pre-selected skill, where the user can describe what they need in free text.
+
+## Why
+
+Choosing a document type upfront ensures the right skill is loaded before the first message, so the AI enters the authoring session with the correct structure, process, and conventions already in context. The dialog also surfaces available document types at the moment they're most relevant — when the user has just decided to create something — without requiring them to know what types exist or how to ask for them.
+
+## User stories
+
+- Patricia can click the new document button and immediately see available document types without navigating away from her current context
+- Patricia can select a document type with a single keypress
+- Eric can start a tech design authoring session with the correct skill loaded from the first message
+- Devon can select "Other" when he doesn't know which template applies
+- Devon can describe what he needs in free text in the AI chat panel
+- Any user sees their recently used document types listed first, with gaps filled by the most commonly created types in the repository
+- Any user sees only the available document type options when fewer than three types exist in the workspace
+
+## Design changes
+
+### User flow
+
+```mermaid
+graph TD
+    A[User clicks new document button] --> B[Build option list: MRU types first, fill gaps with most-used repo types]
+    B --> C{How many types available?}
+    C -->|1 or 2 types| D[Show available types + Other]
+    C -->|3 types| E[Show 3 types + Other]
+    E --> F[Create new dialog appears, centered]
+    D --> F
+    F --> G{User action}
+    G -->|Presses 1–N or clicks type| H[Dialog closes]
+    G -->|Presses N+1 or clicks Other| I[Dialog closes]
+    G -->|Presses Escape| J[Dialog closes, no action]
+    H --> K[Chat panel opens with skill loaded]
+    I --> L[Chat panel opens, no skill selected]
+    K --> M[Authoring session begins]
+    L --> N[User describes what they need in free text]
+```
+
+### UI components
+
+#### Click capture layer
+
+- `fixed inset-0` with no background — invisible, exists only to dismiss the dialog on outside click
+
+#### Dialog container
+
+- `fixed top-1/3 left-1/2 -translate-x-1/2 -translate-y-1/2`
+- `bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl shadow-lg`
+- `w-72 p-2` — fixed width, height auto-fits to content (no min/max height needed; 4 rows + title naturally sizes correctly)
+
+#### Option row (document type or "Other")
+
+- `flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer`
+- Left: Lucide icon `w-4 h-4 text-gray-400 shrink-0`
+- Middle: `flex-1 min-w-0` wrapper with `text-sm text-gray-900 dark:text-gray-100 truncate` — truncates with ellipsis when name is too long
+- Right: shortcut badge `shrink-0 text-xs text-gray-400 bg-gray-100 dark:bg-gray-700 rounded px-1.5 py-0.5`
+
+## Technical changes
+
+### Affected files
+
+*(Populated during tech specs stage)*
+
+### Changes
+
+#### Introduction
+
+**Prerequisites:** `feature-document-authoring.md` complete — `list_skills` exists in `skill_loader.rs` but is not yet exposed as a Tauri command; preferences system exists for persisting MRU state; `useAiChatStore` has `startAuthoring()`.
+
+**Goals:**
+- Dialog appears immediately on button click with no perceptible delay
+- Correct skill is injected into the system prompt from the first message after type selection
+- MRU order persists across sessions
+
+**Non-goals:**
+- Keyboard shortcut registry (ADR-009 infrastructure is not yet built — dialog shortcuts hardcoded locally for now, to be refactored when the registry lands)
+- Natural language type inference (separate issue)
+
+**Note on ADR-009:** The dialog ships with hardcoded number key bindings rather than routing through a central shortcut registry. This is a known deviation from ADR-009 to avoid blocking on registry infrastructure. It should be updated when the registry is built.
+
+#### System design
+
+**Component breakdown:**
+
+- `CreateNewDialog.tsx` (new) — floating dialog; fetches skills and document counts on mount, computes the option list, handles selection and keyboard shortcuts
+- `Sidebar.tsx` (modified) — adds local `dialogOpen` state; button click sets it to `true`; renders `CreateNewDialog` when open
+- `src-tauri/src/commands/skills.rs` (new) — exposes `list_skills` and a new `count_documents_by_type` function as Tauri commands
+- `src/lib/preferences.ts` (modified) — adds `recently_used_skill_types: string[]`, default `[]`
+
+**Option list algorithm** (runs in `CreateNewDialog` on mount):
+1. Read `recently_used_skill_types` from preferences
+2. Fetch `list_skills()` and `count_documents_by_type()` in parallel
+3. Start with MRU types (up to 3), filtered to types that still exist as skills
+4. Fill remaining slots with non-MRU types sorted by repo count descending, then alphabetically ascending on ties
+5. Cap at 3 total type options
+6. Always append "Other" as the final option
+
+**Sequence diagram:**
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant SB as Sidebar
+    participant DL as CreateNewDialog
+    participant BE as Rust backend
+    participant PR as Preferences
+
+    U->>SB: clicks new document button
+    SB->>DL: render dialog (dialogOpen=true)
+    DL->>BE: list_skills() + count_documents_by_type() [parallel]
+    DL->>PR: read recently_used_skill_types
+    BE-->>DL: skills[], counts{}
+    PR-->>DL: mru[]
+    DL->>DL: compute ordered option list
+    U->>DL: selects type (click or keypress)
+    DL->>PR: update recently_used_skill_types
+    DL->>SB: onSelect(skillName), close dialog
+    SB->>SB: startAuthoring(skillName), dialogOpen=false
+```
+
+#### Detailed design
+
+**`list_skills` Tauri command**
+
+Already implemented in `skill_loader.rs`. Add `#[tauri::command]` annotation and register in `lib.rs`. No logic changes.
+
+**`count_documents_by_type` (new Rust function)**
+
+Scans all markdown files in the workspace, reads each file's YAML frontmatter, extracts the `type` field (which matches the skill directory name, e.g. `product-description`), and returns a count per type:
+
+```
+Input: workspace_path: String
+Output: Result<HashMap<String, u32>, String>
+Behavior:
+  - Walk workspace directory (reuse logic from files.rs)
+  - For each .md file, read first ~20 lines to find frontmatter block
+  - Parse YAML between --- delimiters, extract `type` field
+  - Skip files with no frontmatter or no type field
+  - Return map of type name → document count
+```
+
+**Preferences extension**
+
+Add `recently_used_skill_types: Vec<String>` (Rust) / `recently_used_skill_types: z.array(z.string())` (TypeScript) to the preferences schema. Default: empty array. Capped at 3 entries — when a type is selected, prepend it and trim to 3.
+
+**`CreateNewDialog` option list computation**
+
+```
+1. filter mru[] to types present in skills[]
+2. slots = mru[0..3]  (up to 3)
+3. remaining = skills not in slots,
+               sorted by counts[skill] descending,
+               then alphabetically ascending on ties
+4. fill slots from remaining until length === 3 or remaining exhausted
+5. options = slots + ["other"]
+```
+
+#### Security
+
+No new security surface. All file reads are within the workspace path, reusing the existing path validation pattern from `files.rs`.
+
+#### Testing plan
+
+**Unit tests (Vitest):**
+- Option list computation: MRU ordering, gap-filling, alpha tie-breaking, fewer than 3 types, zero types
+- Preferences: `recently_used_skill_types` parse/save round-trip, cap at 3, prepend behavior
+
+**Unit tests (Rust):**
+- `count_documents_by_type`: files with type field, files without frontmatter, empty workspace, type counts with ties
+
+**Component tests:**
+- `CreateNewDialog`: renders correct options, keyboard shortcuts dismiss and select correctly, Escape closes without action, "Other" calls `startAuthoring(null)`
+
+## Task list
+
+- [x] **Story: Rust backend — skill commands**
+  - [x] **Task: Expose `list_skills` as a Tauri command**
+    - **Description**: Add `#[tauri::command]` to the existing `list_skills` function in `skill_loader.rs` and register it in `lib.rs`. No logic changes — it already works, it just isn't callable from the frontend.
+    - **Acceptance criteria**:
+      - [x] `list_skills` callable via `invoke("list_skills", { workspace_path })` from the frontend
+      - [x] Returns `Vec<SkillInfo>` with name and description for each skill
+      - [x] Registered in `lib.rs` invoke handler
+    - **Dependencies**: None
+  - [x] **Task: Implement `count_documents_by_type` Tauri command**
+    - **Description**: In `src-tauri/src/commands/skills.rs`, add a command that walks the workspace directory (reusing logic from `files.rs`), reads the first ~20 lines of each `.md` file to extract YAML frontmatter, reads the `type` field, and returns a `HashMap<String, u32>` of type name → document count. Skip files with no frontmatter or no `type` field.
+    - **Acceptance criteria**:
+      - [x] Returns correct counts for a workspace with multiple document types
+      - [x] Skips files with no frontmatter or missing `type` field gracefully
+      - [x] Returns empty map for an empty workspace
+      - [x] Path validation reuses existing workspace boundary checks
+      - [x] Registered as Tauri command
+      - [x] Unit tests cover: documents with type, documents without frontmatter, empty workspace, type counts with ties
+    - **Dependencies**: None
+
+- [x] **Story: Preferences extension**
+  - [x] **Task: Add `recently_used_skill_types` to preferences**
+    - **Description**: Add `recently_used_skill_types: Option<Vec<String>>` to the Rust `Preferences` struct and `recently_used_skill_types: z.array(z.string()).default([])` to the TypeScript Zod schema. Default to empty array. Existing preferences files without this field must load without error.
+    - **Acceptance criteria**:
+      - [x] Rust struct updated, existing preferences files load without error
+      - [x] TypeScript Zod schema updated with correct default
+      - [x] Save/load round-trip preserves the field
+      - [x] Unit tests cover: missing field defaults to `[]`, round-trip with values
+    - **Dependencies**: None
+
+- [x] **Story: `CreateNewDialog` component**
+  - [x] **Task: Build `CreateNewDialog` component**
+    - **Description**: Create `src/components/CreateNewDialog.tsx`. On mount, fetch `list_skills()` and `count_documents_by_type()` in parallel and read `recently_used_skill_types` from preferences. Compute the option list using the algorithm in the tech spec (MRU first, fill with count-sorted then alpha-sorted remaining, cap at 3, always append "Other"). Render the floating dialog per the design spec: click-capture layer, dialog container, option rows with icon/label/shortcut badge. Number keys 1–N select the corresponding type; the next key selects "Other"; Escape closes without action. On selection, prepend the chosen type to `recently_used_skill_types` (capped at 3), save preferences, and call `onSelect(skillName)` or `onSelect(null)` for "Other". Call `onClose` in all exit paths.
+    - **Acceptance criteria**:
+      - [x] Dialog renders with correct option list (MRU first, gap-filled, capped at 3 + Other)
+      - [x] Fresh workspace with no documents shows types in alphabetical order
+      - [x] Long type names truncate with ellipsis
+      - [x] Number keypresses select the correct option
+      - [x] Escape closes without calling `onSelect`
+      - [x] Click outside (capture layer) closes without calling `onSelect`
+      - [x] Selecting a type updates `recently_used_skill_types` in preferences
+      - [x] "Other" calls `onSelect(null)`
+      - [ ] Dark mode styles apply correctly
+      - [x] Unit tests cover: option list computation, keyboard shortcuts, MRU update, fewer than 3 types
+    - **Dependencies**: "Task: Expose `list_skills` as a Tauri command", "Task: Implement `count_documents_by_type` Tauri command", "Task: Add `recently_used_skill_types` to preferences"
+
+- [x] **Story: Sidebar integration**
+  - [x] **Task: Wire new document button to `CreateNewDialog`**
+    - **Description**: In `Sidebar.tsx`, add local `dialogOpen` state. Change the button's `onClick` from calling `onStartAuthoring` directly to setting `dialogOpen = true`. Render `CreateNewDialog` when `dialogOpen` is true, passing `onSelect(skillName)` (which calls `startAuthoring(skillName)` and sets `dialogOpen = false`) and `onClose` (sets `dialogOpen = false`). Remove the "New document" text label from the button, keeping only the `Plus` icon (this is issue #16 combined).
+    - **Acceptance criteria**:
+      - [x] Clicking the button opens the dialog instead of immediately starting authoring
+      - [x] Selecting a type from the dialog starts the authoring session with the correct skill
+      - [x] Closing the dialog without selecting does not start authoring
+      - [x] Button renders as icon-only (no text label)
+      - [x] `aria-label` and `title="New document"` remain on the button
+    - **Dependencies**: "Task: Build `CreateNewDialog` component"

--- a/.eng-docs/specs/enhancement-chat-box-expansion.md
+++ b/.eng-docs/specs/enhancement-chat-box-expansion.md
@@ -1,0 +1,110 @@
+# Enhancement: Chat Box Expansion
+
+## Parent feature
+
+`feature-ai-chat-assistant.md`
+
+## What
+
+The chat input in the AI panel is replaced with an expandable card-style container. Instead of a fixed single-row textarea, the input grows automatically as the user types — line by line, up to 50% of the panel height, after which it scrolls internally. The card wraps the textarea on top and a persistent toolbar on the bottom, keeping the send button always visible. Users can send with `Enter` or `Cmd+Enter` and insert newlines with `Shift+Enter`.
+
+## Why
+
+A fixed single-row textarea is a poor fit for a conversational AI tool. Users composing longer messages — multi-step questions, document excerpts they want the AI to respond to, detailed context — have no way to see what they've written before sending. The expandable card pattern, used by Claude, ChatGPT, and similar tools, is the established convention for AI chat inputs precisely because it solves this: the input grows with the message, the send button stays put, and users always have full visibility of what they're about to send.
+
+## Goals
+
+1. Users can type multi-line messages without text being hidden behind a truncated single-line input
+2. The input grows automatically with content — no manual action required
+3. The input expands up to 50% of the chat panel height, then scrolls internally
+4. The send button is always visible regardless of input height
+
+## User stories
+
+- User sees the input grow line by line as they type, without taking any action
+- User can insert a newline with `Shift+Enter` and see the box expand to accommodate it
+- User can send a message with `Enter` or `Cmd+Enter`
+- When the input reaches 50% of the chat panel height, it stops growing and scrolls internally instead
+- The send button remains visible at all times regardless of how tall the input is
+
+## Design spec
+
+### Layout
+
+```
+┌─────────────────────────────────────┐
+│ Ask a question...                   │
+│                                     │  ← textarea, grows upward
+│                                     │
+├─────────────────────────────────────┤
+│                            [send ↑] │  ← fixed toolbar, always visible
+└─────────────────────────────────────┘
+```
+
+The input area is a single rounded card containing both the textarea and the toolbar. The textarea has no border of its own — the card provides the container. The toolbar is a fixed-height row that never moves regardless of how tall the textarea gets. Left side of the toolbar is reserved for future actions (file attachment, model selector, etc.).
+
+### UI components
+
+#### Input card
+- `rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800`
+- `focus-within:ring-2 focus-within:ring-blue-500` — ring activates when textarea is focused
+- Contains textarea on top, toolbar on bottom, separated by `border-t border-gray-200 dark:border-gray-700`
+
+#### Textarea
+- No border, no background (`bg-transparent border-none outline-none`)
+- `w-full resize-none px-3 pt-3 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400`
+- Starts at 1 row; auto-grows via `scrollHeight` on every input event
+- Max height: 50% of the chat panel height, computed via a `ref` on the panel container and set as an inline `maxHeight` style
+- `overflow-y-auto` always set — activates naturally once content exceeds max height
+
+#### Toolbar
+- `flex items-center justify-end px-2 py-1.5`
+- Send button: `bg-blue-600 hover:bg-blue-700 text-white rounded-lg p-1.5 disabled:opacity-50`
+- Send icon: `ArrowUp` from Lucide (`w-4 h-4`)
+- Disabled when input is empty or streaming
+
+## Tech spec
+
+**Prerequisites:** AI chat assistant feature — `AiChatPanel.tsx` exists with a working textarea and send flow.
+
+**Changes:** `AiChatPanel.tsx` only. No new files, no store changes, no Tauri changes.
+
+**Auto-grow**: In a `useEffect` watching `input`, reset the textarea height to `'auto'` then set it to `textarea.scrollHeight + 'px'`. Resetting to `auto` first forces the browser to recompute the natural height before reading `scrollHeight`.
+
+**Max height**: Add a `ref` to the outer panel `div` (the `w-96` container). In the same effect, read `panelRef.current.offsetHeight * 0.5` and apply as `maxHeight` on the textarea via inline style. `overflow-y-auto` on the textarea handles scrolling once the max is reached.
+
+**Input card**: Replace the current `flex gap-2` row (textarea + send button side by side) with the card structure from the design spec.
+
+**Keyboard behavior**: Extend the existing `handleKeyDown` — send on `Enter` (without Shift) or `Cmd+Enter` (with metaKey). Shift+Enter falls through to default textarea behavior, inserting a newline.
+
+## Task list
+
+- [ ] **Story: Expandable chat input**
+  - [ ] **Task: Refactor input area into card layout**
+    - **Description**: In `AiChatPanel.tsx`, replace the `flex gap-2` row containing the textarea and send button with a card container per the design spec. The card wraps a textarea on top and a toolbar row on the bottom, separated by a border. The textarea should have no border of its own — the card provides the visual container. Move the send button into the toolbar row, right-aligned. Use `ArrowUp` icon instead of the current `Send` icon.
+    - **Acceptance criteria**:
+      - [ ] Input area renders as a single rounded card with `rounded-xl border`
+      - [ ] `focus-within:ring-2 ring-blue-500` ring activates when the textarea is focused
+      - [ ] Textarea has no visible border or background of its own
+      - [ ] Toolbar is separated from textarea by a top border
+      - [ ] Send button is right-aligned in the toolbar with `ArrowUp` icon
+      - [ ] Send button disabled when input is empty or streaming
+      - [ ] Dark mode styles apply correctly throughout
+    - **Dependencies**: None
+  - [ ] **Task: Implement auto-grow textarea**
+    - **Description**: Add a `ref` to the textarea and a `useEffect` watching `input` state. On each change: set `textarea.style.height = 'auto'`, then set `textarea.style.height = textarea.scrollHeight + 'px'`. Add a `ref` to the outer panel container (`w-96` div) and compute `panelRef.current.offsetHeight * 0.5` to use as the textarea's `maxHeight` inline style. Set `overflow-y-auto` on the textarea so it scrolls internally once the max is reached.
+    - **Acceptance criteria**:
+      - [ ] Textarea starts at 1 row when input is empty
+      - [ ] Textarea grows line by line as content is added
+      - [ ] Textarea stops growing at 50% of the chat panel height
+      - [ ] Textarea scrolls internally once max height is reached
+      - [ ] Height resets to 1 row after a message is sent
+    - **Dependencies**: "Task: Refactor input area into card layout"
+  - [ ] **Task: Add Cmd+Enter send shortcut**
+    - **Description**: In `AiChatPanel.tsx`, update `handleKeyDown` to also trigger `handleSend` when `e.key === 'Enter' && e.metaKey` is true, in addition to the existing `Enter` without Shift. Shift+Enter should continue to fall through to default textarea behavior (newline insertion).
+    - **Acceptance criteria**:
+      - [ ] `Enter` (no modifiers) sends the message
+      - [ ] `Cmd+Enter` sends the message
+      - [ ] `Shift+Enter` inserts a newline and grows the box
+      - [ ] No change to send behavior while streaming
+    - **Dependencies**: "Task: Refactor input area into card layout"

--- a/.eng-docs/specs/enhancement-design-kitchen-sink.md
+++ b/.eng-docs/specs/enhancement-design-kitchen-sink.md
@@ -1,0 +1,52 @@
+# Enhancement: Design kitchen sink
+
+## Parent feature
+
+`feature-design-system.md`
+
+## What
+
+Adds a dev-only kitchen sink view to the application that renders all design tokens and core component variants in a single scrollable page. The view is accessible in the Tauri dev build and is excluded from production. It serves as the visual validation tool for the design system — allowing review and sign-off of the actual rendered output before component migration begins.
+
+## Why
+
+`design-system.md` defines the design system on paper, and `app.css` encodes the tokens in code, but neither answers the question "does this actually look right?" The kitchen sink view provides that answer. It lets the user see every color swatch, type size, component variant, and interaction state rendered in the real app with real CSS — not in a mockup or a browser tab, but in the Tauri desktop build. Sign-off on the kitchen sink is the gate before component migration work begins.
+
+## User stories
+
+- The user can open the kitchen sink view in the dev build and see all color tokens rendered as labeled swatches in both dark and light modes
+- The user can review the complete type scale, spacing scale, and all component variants in one place
+- The user can identify any token value or component pattern that looks wrong and request a correction before it propagates to real components
+- Eric can use the kitchen sink as a reference while implementing new components
+
+## Design changes
+
+The kitchen sink is a dev tool, not a user-facing feature. Its layout and organization should be functional and clear but does not need to follow the design system itself — it exists to display the design system. Structure:
+
+- Sections matching `design-system.md` categories: Colors, Typography, Spacing, Border Radius, Shadows, Motion, Components
+- Each section renders the relevant tokens or variants with their names and values labeled
+- Component section includes: all button variants and states, input states, badge/tag variants, a sample sidebar (static), a sample dialog trigger, a sample context menu trigger
+
+## Technical changes
+
+### Affected files
+
+- `src/components/DesignKitchen.tsx` — new component; the kitchen sink view
+- `src/App.tsx` — add a dev-only keyboard shortcut (e.g., Cmd+Shift+K) to open the kitchen sink view, guarded by `import.meta.env.DEV`
+
+### Changes
+
+`DesignKitchen.tsx` is a single React component that renders all sections. It is excluded from production builds via:
+
+```tsx
+// In App.tsx
+if (import.meta.env.DEV) {
+  // register keyboard shortcut to render <DesignKitchen />
+}
+```
+
+The component renders static examples — no interactivity beyond triggering states for demonstration (e.g., a button to show a dialog variant).
+
+## Task list
+
+*(To be completed after `enhancement-encode-design-tokens.md` is implemented — the kitchen sink depends on the token layer being in place to render meaningfully.)*

--- a/.eng-docs/specs/enhancement-encode-design-tokens.md
+++ b/.eng-docs/specs/enhancement-encode-design-tokens.md
@@ -1,0 +1,67 @@
+# Enhancement: Encode design tokens
+
+## Parent feature
+
+`feature-design-system.md`
+
+## What
+
+Encodes all design tokens defined in `design-system.md` into Tailwind v4's `@theme {}` block in `src/app.css`, making every token available as a CSS custom property throughout the application. This is the implementation step that follows the specification step — `design-system.md` defines what the tokens are; this enhancement makes them real in the codebase.
+
+## Why
+
+`design-system.md` is the source of truth for every visual decision in the app, but it has no effect on the UI until its values are encoded as CSS custom properties that components can reference. This enhancement closes that gap. It is also the prerequisite for the kitchen sink preview and all component migration enhancements — nothing can be migrated to the design system until the token layer exists.
+
+## User stories
+
+- Eric can reference any design token by its semantic name (e.g., `--color-bg-elevated`, `--font-size-ui-base`) in any component without defining the value inline
+- Eric can be confident that changing a token value in `app.css` propagates consistently across the entire app
+- Eric implementing a new component can write styles using only token names, with no raw color, spacing, or size values
+
+## Design changes
+
+None — this enhancement is a code-only change. All design decisions are specified in `design-system.md`.
+
+## Technical changes
+
+### Affected files
+
+- `src/app.css` — add `@theme {}` block encoding all tokens from `design-system.md`
+
+### Changes
+
+Add a `@theme {}` block to `src/app.css` immediately after the Tailwind import. The block should define one CSS custom property per token, organized by category matching `design-system.md`:
+
+```css
+@import "tailwindcss";
+@plugin "@tailwindcss/typography";
+
+@theme {
+  /* Colors — dark mode base (light mode via .light class or media query per theming spec) */
+  /* Typography */
+  /* Spacing */
+  /* Border radius */
+  /* Shadow / elevation */
+  /* Motion */
+}
+```
+
+Exact token names and values are taken directly from `design-system.md`. Do not invent token names — use the names as defined there.
+
+## Task list
+
+**1. Write `@theme {}` block**
+- Read the Tailwind v4 encoding guide section in `design-system.md`
+- Write the complete `@theme {}` block to `src/app.css` immediately after the existing `@import` and `@plugin` lines
+- Include all mode-independent token categories: typography (font families, UI scale, document scale), spacing, control dimensions, padding, border radius, motion, accent colors, state colors, shadows
+- Use exact token names and values from `design-system.md` — do not invent or modify any names
+
+**2. Write `@layer base` color mode block**
+- Add an `@layer base` block below `@theme {}`
+- Define all `--color-bg-*`, `--color-text-*`, and `--color-border-*` tokens at `:root` using dark mode values as the default
+- Add a `@media (prefers-color-scheme: light)` override block inside `@layer base` with light mode values for the same tokens
+
+**3. Verify and commit**
+- Run `npm run build` — confirm no new errors introduced by the CSS change
+- Run `npm test` — confirm all tests pass
+- Commit on a feature branch; open PR targeting main

--- a/.eng-docs/specs/enhancement-macos-title-bar.md
+++ b/.eng-docs/specs/enhancement-macos-title-bar.md
@@ -1,0 +1,54 @@
+# Enhancement: macOS title bar
+
+## Parent feature
+
+`feature-design-system.md`
+
+## What
+
+Replaces the default macOS system title bar with a native overlay treatment using Tauri's `titleBarStyle: "Overlay"` configuration. The system title bar background is removed; web content fills the full window including the title bar area, and the native macOS traffic lights remain embedded in the app chrome. A custom `TitleBar` component provides the drag region and title bar content layout. This enhancement also retires the existing separate settings OS window — the Tauri command and window configuration are removed as part of this change.
+
+## Why
+
+The default system title bar is the clearest visual signal that an app is "a website in a window." Removing it and integrating the traffic lights directly into the app chrome is one of the highest-impact single changes for achieving a desktop-native feel. The settings OS window retirement is included here because it directly conflicts with the in-app overlay principle established in the design system — it cannot ship in a post-design-system world.
+
+## User stories
+
+- Patricia opens the app and sees the macOS traffic lights embedded in the app frame, not floating above a grey system title bar
+- Patricia can drag the window by clicking anywhere in the title bar content area that is not an interactive control
+- Patricia presses Cmd+, and the settings experience opens within the app rather than spawning a new OS window
+- The app window integrates visually with macOS at the same level as apps like Linear and Arc
+
+## Design changes
+
+Per `design-system.md` title bar pattern:
+- Title bar height and background color as specified
+- Traffic lights zone (left side, no-drag area) as specified
+- Drag region covers remaining title bar area
+- Title bar content layout (workspace label, right-side controls) as specified
+- Sidebar header aligns with and extends into the title bar area
+
+## Technical changes
+
+### Affected files
+
+- `src-tauri/tauri.conf.json` — add `titleBarStyle: "Overlay"` to window configuration
+- `src/components/TitleBar.tsx` — new component
+- `src/App.tsx` — integrate `TitleBar`, remove settings window invocation
+- `src-tauri/src/lib.rs` (or equivalent) — remove `open_settings_window` command
+- `src-tauri/tauri.conf.json` — remove separate settings window configuration
+
+### Changes
+
+**`tauri.conf.json`**: Add to the window object:
+```json
+"titleBarStyle": "Overlay"
+```
+
+**`TitleBar.tsx`**: New component that renders the title bar content area. Sets `-webkit-app-region: drag` on the container and `-webkit-app-region: no-drag` on all interactive child elements. Accounts for the traffic lights zone (~78px from the left edge on macOS). Uses design system tokens for height, background, and typography.
+
+**Settings window retirement**: Remove the `open_settings_window` Tauri command from the Rust backend and its corresponding window entry from `tauri.conf.json`. Update `App.tsx` to remove the `invoke("open_settings_window")` call. The Cmd+, shortcut handler remains but routes to the in-app settings panel (implemented in `enhancement-settings-panel.md`). If that enhancement is not yet implemented, the shortcut can be a no-op temporarily.
+
+## Task list
+
+*(To be completed after `design-system.md` is finalized — task breakdown depends on the specific title bar design patterns defined there.)*

--- a/.eng-docs/specs/enhancement-migrate-ai-chat.md
+++ b/.eng-docs/specs/enhancement-migrate-ai-chat.md
@@ -1,0 +1,42 @@
+# Enhancement: Migrate AI chat panel to design system
+
+## Parent feature
+
+`feature-design-system.md`
+
+## What
+
+Migrates the AI chat panel and chat message components to use design system tokens for all visual properties. Implements the panel component patterns defined in `design-system.md` for the chat surface — background, typography, message layout, input area, and the panel's relationship to the document area.
+
+## Why
+
+The AI chat panel is a primary collaborative surface in Episteme — users spend significant time interacting with it during authoring, review, and approval workflows. Bringing it into the design system ensures it reads as a native part of the application rather than a visually separate component bolted on.
+
+## User stories
+
+- Patricia opens the AI chat panel and sees it match the visual language of the sidebar and document area
+- Patricia can read AI responses in the chat panel with the same typographic comfort as reading documents
+- Eric implementing new chat features (message types, actions) has a consistent visual baseline to build on
+
+## Design changes
+
+Per `design-system.md` panel and component patterns:
+- Chat panel background, border treatment, and width as specified
+- Message typography using UI token category
+- Input area using the standardized Input primitive from `enhancement-migrate-interactive-components.md`
+- All color and spacing values replaced with semantic token references
+
+## Technical changes
+
+### Affected files
+
+- `src/components/AiChatPanel.tsx` — apply design system tokens; implement panel layout per spec
+- `src/components/ChatMessage.tsx` — apply design system tokens for message typography and layout
+
+### Changes
+
+Replace hardcoded Tailwind classes with design system token references throughout both components. Migrate the input area in `AiChatPanel.tsx` to use the `Input` primitive once `enhancement-migrate-interactive-components.md` is implemented. No behavior changes — visual migration only.
+
+## Task list
+
+*(To be completed after `design-system.md` is finalized and `enhancement-encode-design-tokens.md` is implemented.)*

--- a/.eng-docs/specs/enhancement-migrate-document-area.md
+++ b/.eng-docs/specs/enhancement-migrate-document-area.md
@@ -1,0 +1,43 @@
+# Enhancement: Migrate document area to design system
+
+## Parent feature
+
+`feature-design-system.md`
+
+## What
+
+Migrates the document viewer and frontmatter bar to use design system tokens. Implements the document area component patterns defined in `design-system.md`, including the document column width, content padding, and the frontmatter bar redesign. Note: document content typography (rendered Markdown) is governed by `--font-size-doc-*` tokens defined in the design system but fully implemented in the follow-on markdown rendering feature.
+
+## Why
+
+The document area is the primary working surface — where users spend the most time reading and writing. Migrating it to the design system gives the reading experience the correct background, padding, and frontmatter treatment, even before the full markdown rendering improvements ship.
+
+## User stories
+
+- Patricia opens a document and sees a calm, focused reading surface with the correct background color and content width
+- Patricia sees the frontmatter bar redesigned to match the design system's component patterns
+- Eric can reference the document area implementation as the canonical example of applying document-category tokens
+
+## Design changes
+
+Per `design-system.md` document area and frontmatter bar patterns:
+- Document column width, horizontal padding, and background color as specified
+- Frontmatter bar: key/value layout, typography, color, and truncation behavior as specified
+- All color and spacing values replaced with semantic token references
+
+## Technical changes
+
+### Affected files
+
+- `src/components/DocumentViewer.tsx` — apply design system tokens; implement document column layout
+- `src/components/FrontmatterBar.tsx` — full visual redesign per design-system.md frontmatter bar pattern
+
+### Changes
+
+Replace hardcoded Tailwind classes with design system token references. Implement the exact document area layout (max-width, padding, background) from `design-system.md`. Redesign `FrontmatterBar.tsx` to match the specified component pattern — this may involve structural changes to the component, not just token substitution.
+
+Document content typography (`--font-size-doc-*` tokens) should be applied to the prose container at this stage, even though the full markdown rendering improvements are deferred.
+
+## Task list
+
+*(To be completed after `design-system.md` is finalized and `enhancement-encode-design-tokens.md` is implemented.)*

--- a/.eng-docs/specs/enhancement-migrate-interactive-components.md
+++ b/.eng-docs/specs/enhancement-migrate-interactive-components.md
@@ -1,0 +1,49 @@
+# Enhancement: Migrate interactive components to design system
+
+## Parent feature
+
+`feature-design-system.md`
+
+## What
+
+Establishes standardized `Button` and `Input` primitive components using design system tokens, and migrates all existing call sites to use them. Implements the button and input component patterns defined in `design-system.md` across all variants (primary, secondary, ghost, destructive for buttons; default, focused, error, disabled for inputs). Also resolves the shadcn/Radix strategy decision from the design spec — whichever approach was approved, this enhancement implements the accessible primitive layer.
+
+## Why
+
+Buttons and inputs are the most frequently used interactive components in the app. Without standardized primitives, every feature adds its own button styling, accumulating inconsistencies that compound over time. Establishing these primitives now gives every future feature a correct, token-referenced starting point with accessibility built in.
+
+## User stories
+
+- Eric can use `<Button variant="primary">` or `<Button variant="ghost">` anywhere in the app and get the correct visual output without writing any styles
+- Eric implementing a new feature never writes a raw `<button>` element with inline Tailwind classes
+- All interactive elements have consistent focus states, hover states, and disabled states across the app
+- All button and input interactions are keyboard-accessible and meet WCAG AA contrast requirements
+
+## Design changes
+
+Per `design-system.md` button and input component patterns:
+- All button variants, sizes, and states as specified
+- All input states as specified
+- Token references for every visual property — no hardcoded values
+
+## Technical changes
+
+### Affected files
+
+- `src/components/ui/Button.tsx` — new primitive component
+- `src/components/ui/Input.tsx` — new primitive component
+- `src/components/Sidebar.tsx` — migrate button usage
+- `src/components/CreateNewDialog.tsx` — migrate button and input usage
+- `src/components/AiChatPanel.tsx` — migrate button and input usage
+- `src/components/SettingsView.tsx` / `src/components/SettingsPanel.tsx` — migrate form inputs
+- `src/App.tsx` — migrate toolbar button usage
+
+### Changes
+
+Create `src/components/ui/Button.tsx` and `src/components/ui/Input.tsx` implementing the patterns from `design-system.md`. If the Radix UI approach was approved, these wrap Radix primitives with design system styling. If shadcn was approved, they are generated shadcn components with all default styles replaced.
+
+Migrate all existing `<button>` and `<input>` elements across the codebase to use the new primitives.
+
+## Task list
+
+*(To be completed after `design-system.md` is finalized and `enhancement-encode-design-tokens.md` is implemented.)*

--- a/.eng-docs/specs/enhancement-migrate-overlays.md
+++ b/.eng-docs/specs/enhancement-migrate-overlays.md
@@ -1,0 +1,45 @@
+# Enhancement: Migrate overlays to design system
+
+## Parent feature
+
+`feature-design-system.md`
+
+## What
+
+Migrates dialogs, context menus, popovers, and the create new document dialog to use design system tokens and component patterns. Implements the overlay component patterns defined in `design-system.md` — all overlays render within the application window (no separate OS windows), with the correct background, elevation, border radius, and motion treatment.
+
+## Why
+
+Overlays are the highest-elevation components in the visual hierarchy — they appear above everything else and define how the app handles transient UI surfaces. Without design system tokens, each overlay makes independent decisions about background color, shadow, and border radius, producing a visually inconsistent experience. Standardizing them also enforces the in-app overlay principle: if all overlays use the same primitive, there is no path to accidentally spawning an OS window.
+
+## User stories
+
+- Patricia opens the create new document dialog and sees it rendered within the app with the correct elevation treatment
+- Patricia right-clicks in the file tree and sees a context menu that matches the visual language of the rest of the app
+- All overlay interactions use the correct motion tokens (enter/exit transitions as specified)
+- Eric implementing a new overlay uses the established dialog or popover primitive and gets correct elevation, motion, and accessibility for free
+
+## Design changes
+
+Per `design-system.md` dialog, context menu, and popover patterns:
+- Background, border, border radius, and elevation (shadow or color-contrast-based) as specified
+- Motion: enter/exit transitions using the approved motion tokens
+- Backdrop treatment for modal dialogs as specified
+- All color and spacing values replaced with semantic token references
+
+## Technical changes
+
+### Affected files
+
+- `src/components/ui/Dialog.tsx` — new primitive component (wraps Radix Dialog or shadcn Dialog per approved strategy)
+- `src/components/ui/ContextMenu.tsx` — new primitive component
+- `src/components/ui/Popover.tsx` — new primitive component
+- `src/components/CreateNewDialog.tsx` — migrate to use Dialog primitive
+
+### Changes
+
+Create overlay primitives in `src/components/ui/` implementing the patterns from `design-system.md`. Migrate `CreateNewDialog.tsx` to use the new `Dialog` primitive. All overlay primitives must use design system tokens for every visual property — no hardcoded values.
+
+## Task list
+
+*(To be completed after `design-system.md` is finalized and `enhancement-encode-design-tokens.md` is implemented.)*

--- a/.eng-docs/specs/enhancement-migrate-sidebar.md
+++ b/.eng-docs/specs/enhancement-migrate-sidebar.md
@@ -1,0 +1,41 @@
+# Enhancement: Migrate sidebar to design system
+
+## Parent feature
+
+`feature-design-system.md`
+
+## What
+
+Migrates the sidebar and file tree components to use design system tokens for all visual properties — colors, typography, spacing, density, border radius, and interaction states. Implements the sidebar component pattern defined in `design-system.md`, including the correct width, item height, section header treatment, icon sizing, and hover/selected/active states.
+
+## Why
+
+The sidebar is the primary persistent surface of the application — it is visible on every screen and sets the first impression of the app's density and visual quality. It is the highest-priority component migration because its before/after difference is the most visible signal that the design system is working.
+
+## User stories
+
+- Patricia sees a sidebar that feels native and compact, not like a website navigation panel
+- Patricia can distinguish selected, hover, and default states clearly without visual noise
+- Eric can reference the sidebar implementation as the canonical example of how to apply design system tokens to a navigation component
+
+## Design changes
+
+Per `design-system.md` sidebar pattern:
+- Width, item height, section header styles, icon sizing, and all interaction states as specified
+- All color values replaced with semantic token references
+
+## Technical changes
+
+### Affected files
+
+- `src/components/Sidebar.tsx` — apply design system tokens; implement design spec layout
+- `src/components/FileTree.tsx` — apply design system tokens
+- `src/components/FileTreeItem.tsx` — apply design system tokens; implement item height, icon sizing, hover/selected states per spec
+
+### Changes
+
+Replace all hardcoded Tailwind color classes, spacing values, and sizing with design system token references. Implement the exact component pattern from `design-system.md`. No behavior changes — this is a visual migration only.
+
+## Task list
+
+*(To be completed after `design-system.md` is finalized and `enhancement-encode-design-tokens.md` is implemented.)*

--- a/.eng-docs/specs/enhancement-migrate-toolbar.md
+++ b/.eng-docs/specs/enhancement-migrate-toolbar.md
@@ -1,0 +1,40 @@
+# Enhancement: Migrate toolbar to design system
+
+## Parent feature
+
+`feature-design-system.md`
+
+## What
+
+Migrates the main toolbar and welcome screen to use design system tokens. Implements the toolbar component pattern defined in `design-system.md`, including the correct height, button sizing, and the mode-awareness rule (formatting tools visible only in edit mode).
+
+## Why
+
+The toolbar sits between the title bar and the document area and is visible on every document view. Migrating it completes the top-of-window chrome alongside the title bar enhancement, giving the app a fully consistent header region.
+
+## User stories
+
+- Patricia sees a toolbar that matches the density and visual language of the sidebar and title bar
+- Patricia only sees formatting tools when in edit mode — the toolbar does not display irrelevant controls
+- Eric can implement new toolbar buttons by following the existing token-referenced pattern
+
+## Design changes
+
+Per `design-system.md` toolbar pattern:
+- Height, button sizing, separator treatment, and mode-awareness behavior as specified
+- All color values replaced with semantic token references
+
+## Technical changes
+
+### Affected files
+
+- `src/App.tsx` — toolbar area; apply design system tokens and correct height
+- `src/components/WelcomeScreen.tsx` — apply design system tokens
+
+### Changes
+
+Replace hardcoded Tailwind classes with design system token references in the toolbar area of `App.tsx`. Implement mode-awareness for toolbar controls per the design spec. Migrate `WelcomeScreen.tsx` to use design system tokens for background, typography, and any interactive elements.
+
+## Task list
+
+*(To be completed after `design-system.md` is finalized and `enhancement-encode-design-tokens.md` is implemented.)*

--- a/.eng-docs/specs/enhancement-settings-panel.md
+++ b/.eng-docs/specs/enhancement-settings-panel.md
@@ -1,0 +1,53 @@
+# Enhancement: Settings panel
+
+## Parent feature
+
+`feature-design-system.md`
+
+## What
+
+Replaces the retired settings OS window with an in-app settings panel that follows the Linear-style navigation pattern. When the user opens settings (Cmd+,), the app navigates to a settings "place" — the main content area is replaced with settings content, and the sidebar transforms into a settings navigation menu. A "Back to app" control with a left chevron at the top of the sidebar returns the user to their previous state. This is not a dialog or overlay — it is a navigation mode, and it should feel like the app went somewhere.
+
+## Why
+
+Settings is the primary secondary experience in the app — the place every user visits to configure their workspace. The previous implementation (a separate OS window) conflicted with the design system's in-app overlay principle and broke the spatial model of the application. The new pattern, drawn directly from Linear's implementation, keeps the user inside the application context and makes it immediately clear how to return to their work.
+
+## User stories
+
+- Patricia presses Cmd+, and the settings panel opens within the app without spawning a new window
+- Patricia can navigate between settings categories using the sidebar navigation that replaces the file tree
+- Patricia can return to her document and the exact sidebar state she left by clicking "Back to app"
+- Eric can add new settings categories by adding entries to the settings navigation structure without modifying the core layout
+
+## Design changes
+
+Per `design-system.md` settings and navigation experience pattern:
+- Main content area transitions to settings content view
+- Sidebar replaces file tree with settings category navigation
+- "Back to app" link with left chevron at top of sidebar
+- Transition behavior between normal mode and settings mode as specified
+- Settings category content uses standard panel/form component patterns from the design system
+
+## Technical changes
+
+### Affected files
+
+- `src/components/SettingsPanel.tsx` — new component; the settings content area
+- `src/components/SettingsNav.tsx` — new component; the settings sidebar navigation
+- `src/App.tsx` — add settings mode state; conditionally render SettingsPanel and SettingsNav
+- `src/components/Sidebar.tsx` — accept and render SettingsNav when in settings mode
+- `src/components/SettingsView.tsx` — existing file; migrate content into SettingsPanel
+
+### Changes
+
+Settings mode is managed as application state (likely a boolean or enum in the workspace store or a new settings store). When active:
+- `App.tsx` renders `SettingsPanel` in place of `DocumentViewer`
+- `Sidebar` renders `SettingsNav` (with "Back to app" at top) in place of `FileTree`
+
+The Cmd+, shortcut handler in `App.tsx` (currently invoking the retired OS window command) is updated to toggle settings mode instead.
+
+Existing settings content in `SettingsView.tsx` is migrated into `SettingsPanel.tsx` and styled using design system tokens.
+
+## Task list
+
+*(To be completed after `design-system.md` is finalized and `enhancement-encode-design-tokens.md` is implemented.)*

--- a/.eng-docs/specs/feature-design-system.md
+++ b/.eng-docs/specs/feature-design-system.md
@@ -1,0 +1,519 @@
+# Feature: Design system
+
+## What
+
+Episteme's visual design needs to operate as a first-class desktop product. This feature establishes a complete design system for Episteme — a consistent visual language covering color, typography, spacing, density, component patterns, and window chrome — that makes the application feel like a purpose-built desktop tool rather than a website rendered in a browser frame.
+
+The design system delivers two things. First, a token vocabulary: a defined set of named values for every visual decision in the application, from background colors and text sizes to border radii and motion timing. These tokens become the single source of truth that every present and future component references, eliminating ad-hoc visual decisions. Second, a set of core component patterns that specify how the application's major UI surfaces should look and behave — sidebar, toolbar, document area, buttons, inputs, dialogs, and menus — including a custom window frame treatment for both macOS and Windows.
+
+The result is a visual foundation that all future Episteme features build on, and a reference document precise enough that any engineer can implement a new component without guessing at visual decisions.
+
+## Why
+
+Episteme is a professional desktop tool. First impressions are formed in seconds, and an application that looks like a website in a browser frame signals low quality before a user has read a single document. The design system exists to close that gap — to make Episteme look and feel like software people want to spend hours in, alongside tools like Linear and Bear.
+
+Beyond first impressions, the absence of a design system has a compounding cost. Every component built without one requires engineers to make visual decisions from scratch — what shade of gray, which border radius, how much padding — and those decisions accumulate into an inconsistent UI that becomes increasingly expensive to fix. Establishing the system now, before more features are built on top of the current ad-hoc styles, is dramatically cheaper than retrofitting later. It also creates a shared language: a token vocabulary that engineers, AI collaborators, and future contributors can all reference, so "primary button" or "border-subtle" mean the same thing to everyone.
+
+The token foundation established here is also the prerequisite for two follow-on investments: markdown rendering improvements and theming. Both require a stable design language to build on.
+
+## Personas
+
+- **Eric: Engineer** — primary consumer of the design system spec; implements components using defined tokens and patterns
+- **Patricia: Product Manager** — daily user of the application; directly experiences the quality of the resulting UI
+- All other personas (Raquel, Aaron, Olivia) benefit as end users of the improved desktop feel
+
+## Narratives
+
+### Eric implements a new component
+
+Eric picks up a task to build the comment thread sidebar for the review workflow — a panel he hasn't seen specced yet. Rather than opening the codebase and copying styles from whatever component is nearby, he opens `design-system.md` first. The token reference tells him exactly what he needs: `--color-bg-elevated` for the panel background, `--color-border-subtle` for the dividers between comments, `--font-size-sm` with `--color-text-secondary` for timestamps, and `--radius-md` for the avatar bubbles. He picks `ghost` button variant for the resolve action. Every decision is already made.
+
+Eric builds the component in about an hour. The result looks identical to the rest of the app — same density, same type treatment, same hover states — without him having coordinated with anyone about the visual design. When he opens a PR, there are no comments about inconsistent padding or mismatched grays. The component simply fits.
+
+Three months later, a second engineer joins the project and is asked to add a reactions feature to comment threads. She opens `design-system.md`, finds the badge token definitions and the icon sizing guidelines, and implements the feature with the same confidence Eric had. The design system has done its job.
+
+### Patricia opens Episteme after the redesign
+
+Patricia opens Episteme for the first time since the redesign shipped. The first thing she notices is the window — the title bar is gone, replaced by a seamless content area where the macOS traffic lights nestle in the top-left corner of the app frame, integrated into the chrome rather than hovering above it. It looks like software, not a browser tab.
+
+She selects a document from the sidebar and reads through it. The sidebar is narrower and denser than she remembered — more like a file manager than a webpage nav — and the document area gives her a calm, focused reading surface. The type is crisp at exactly the right size. She doesn't consciously notice any of this; she just finds herself reading without friction.
+
+Patricia presses Cmd+, to open settings. The main content doesn't disappear into a new OS window — instead, a settings panel fills the app in place, the document fading behind it. She updates her AWS profile and closes the panel. The document is right where she left it. Nothing felt like it left the application.
+
+## User stories
+
+**Eric implements a new component**
+
+- Eric can look up any visual decision (color, spacing, type, radius, shadow) by name in `design-system.md` without consulting anyone
+- Eric can implement a new component that visually matches the rest of the app without guessing at values
+- Eric can ship UI PRs that don't require design review for basic visual consistency
+- A new engineer can onboard to the design system and implement compliant components from the reference alone
+
+**Patricia opens Episteme after the redesign**
+
+- Patricia can open Episteme and perceive it as a native desktop application, not a website in a browser frame
+- Patricia can read documents in a focused, low-noise environment with appropriate typographic density
+- Patricia can open settings without leaving the application context
+- All personas experience a window chrome that integrates with the OS rather than sitting on top of it
+
+## Goals
+
+- Every color, spacing, radius, shadow, and motion value in the app is defined as a named token in `design-system.md` with no undocumented one-offs
+- Any engineer can implement a new UI component using only the design system reference, with zero ambiguity about visual values
+- The application window uses native-integrated chrome on macOS (traffic lights embedded, no system title bar) and a custom frame on Windows
+- All overlay experiences (settings, dialogs, panels) render within the application window — no separate OS windows
+- The design system is encoded as Tailwind v4 CSS variables, ready to support theming in a future phase
+
+## Non-goals
+
+- Theme switching (light/dark toggle, custom themes) — deferred to a follow-on theming feature
+- Markdown/Tiptap rendering improvements — separate follow-on feature
+- Migrating every existing component to the new tokens — covered by follow-on enhancement specs per component area
+
+## Design spec
+
+This section is a **design brief** for the execution session that produces `design-system.md`. It does not contain the answers — it contains the questions to answer, the inputs to consider, and the tradeoffs to resolve. The execution session reads this brief, interviews the user to close any open questions, researches the inspiration sources, then works through each decision area to produce the final spec.
+
+### Purpose and approach
+
+The execution session's output is a fully-specified `design-system.md` that replaces the current stub. Every decision area below must result in concrete, named token values — no ranges, no "approximately," no "similar to." An engineer should be able to read the result and implement any component with zero follow-up questions.
+
+Dark mode is the primary mode. Light mode is fully specified but secondary.
+
+**Ignore all existing design decisions.** Any design-related content in `app.md`, `design-system.md`, component files, or anywhere else in the codebase should be treated as a placeholder. No prior design work was done intentionally — the entire visual layer is being established from scratch here. Do not use existing values as anchors or defaults.
+
+**Favor cross-platform consistency.** Where there is a choice between a platform-native approach and a consistent cross-platform approach, prefer consistency within reason.
+
+### Inspiration sources
+
+The execution session should research these sources in depth before making recommendations. For each source, the goal is to extract specific, concrete values — CSS variable values, pixel measurements, hex/oklch colors — not just impressions. Use browser devtools to inspect CSS where the app is web-accessible. For native macOS apps, inspect screenshots and look for design teardowns. **If access requires a login (e.g., Linear's app requires an account), ask the user to open devtools on the relevant page and share the CSS output** — this is a reasonable ask and worth doing to get accurate values.
+
+**Primary reference — Linear (CSS-inspected, values confirmed)**
+
+Linear's CSS was inspected directly. The following values are confirmed and should be used as concrete inputs during execution, not re-researched:
+
+*Font*
+- UI font family: `"Inter Variable", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif`
+- Monospace font family: `"Berkeley Mono", "SFMono Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace`
+
+*Layout dimensions*
+- Sidebar width: `244px`
+- Header/toolbar height: `39px`
+- Nav item height: `28px` @ `16px` font (body default)
+- Button height: `28px` @ `13px` font
+- Menu item height: `32px` @ `13px` font
+- Control border radius: `4px`
+
+*Dark mode color palette*
+- Sidebar background: `#090909`
+- Content background: `#101012`
+- Content bg (component level): `#15161c`
+- Header/card background: `#191a22`
+- Elevated surface: `#222430`
+- Hover/active surface: `#272937`
+- Quaternary bg: `#1b1c27`
+- Border primary: `#20222f` / secondary: `#292b38` / tertiary: `#313240`
+- Text primary: `#ffffff` / secondary: `#e4e4ed` / tertiary: `#999aa1` / quaternary: `#5d5e65`
+- Accent/focus: `#575ac6`
+
+*Light mode color palette*
+- Sidebar background: `#f5f5f5`
+- Content background: `#fcfcfc`
+- Border: `#e0e0e0`
+- Text secondary: `#b0b5c0`
+- Text primary: `#23252a`
+
+*Motion durations*
+- Instant: `0s` / Fast: `0.1s` / Normal: `0.15s` / Slow: `0.25s` / Deliberate: `0.35s`
+
+*Elevation in dark mode*
+- Context menus: **no box-shadow** — elevation communicated via background color contrast alone (`#222430` over `#101012`)
+
+Design philosophy post for reference: https://linear.app/now/how-we-redesigned-the-linear-ui
+
+**Secondary references — native macOS apps**
+
+Raycast, Things 3, Bear, Arc, and Craft are all native macOS apps. Their design language cannot be extracted via CSS. During the execution session, use these approaches:
+- **Digital Color Meter** (built into macOS at `/Applications/Utilities/`) — sample exact colors from any pixel on screen
+- **Accessibility Inspector** (in Xcode at `/Applications/Xcode.app/Contents/Applications/`) — inspect element bounds, heights, and hierarchy of any running app
+- **Screenshots + Figma** — import a screenshot into Figma (free) to measure pixel dimensions
+
+These apps are validation and inspiration sources, not primary data sources. The goal is to confirm that Linear's choices are consistent with other high-quality desktop tools, and to draw on their strengths in areas Linear doesn't cover (Bear for document reading, Arc for window chrome integration, Things 3 for sidebar density).
+
+### Decision areas
+
+Each area below states: (1) the question(s) to resolve and (2) known inputs. Inputs marked **[confirmed]** come from primary sources (the Linear blog post or similar). Inputs marked **[research]** need verification during execution — treat them as starting hypotheses, not facts.
+
+---
+
+#### Typography
+
+**Questions to answer**
+- What is the complete UI type scale (sizes, line heights, weights) for UI text? Include: tiny labels, secondary text, primary UI text, dialog content/labels, section headers.
+- What is the complete document content scale for rendered Markdown? This is a separate token category — document reading has different requirements than UI density.
+- What specific Inter weights are used and where?
+
+**Inputs**
+- **[confirmed]** Font family: `"Inter Variable"` as primary UI font (with SF Pro Display and system font fallbacks). Inter Variable is the variable font version of Inter — use this specifically, not static Inter.
+- **[confirmed]** Monospace: `"Berkeley Mono"` as primary (a premium monospace). Given this requires a paid license, decide during execution whether to license it, use a free alternative (JetBrains Mono, Fira Code), or fall back to system mono.
+- **[confirmed]** Linear uses Inter Display for headings — source: blog post. This is a display-optimized variant; confirm whether Inter Variable covers this or whether a separate Inter Display import is needed.
+- **[confirmed]** Controls, buttons, inputs, menus: `13px` font size
+- **[confirmed]** Sidebar nav items: `16px` font size (inheriting body default — not a compact size)
+- **[research]** Complete UI type scale beyond these two data points — use Digital Color Meter and Accessibility Inspector on reference apps, or derive from the confirmed values plus desktop convention
+- **[research]** Document content type scale — derive from Bear and Craft inspection; prioritize readability over density
+
+**Two token categories required**
+- `--font-size-ui-*` tokens: governs all chrome — sidebar, toolbar, buttons, inputs, menus, dialogs, labels. Confirmed range: 13–16px.
+- `--font-size-doc-*` tokens: governs rendered Markdown content — headings, body, code, captions. Prioritize readability over density. Implementation deferred to the markdown rendering feature, but tokens must be defined here.
+
+---
+
+#### Color tokens
+
+**Questions to answer**
+- What color space for token definition?
+- What is the complete semantic token set for dark mode? (background levels, text levels, border levels, accent, state colors)
+- What is the complete semantic token set for light mode?
+- What accent color for Episteme?
+- How many background elevation levels are needed?
+
+**Inputs**
+- **[confirmed]** Linear uses LCH color space for theme generation (blog post). Modern CSS supports `oklch()` natively — perceptually uniform like LCH and the current CSS standard. Recommended starting point; present to user for sign-off.
+- **[confirmed]** Linear's palette uses near-pure gray neutrals with minimal chromatic bias — text and icons are not tinted (blog post).
+- **[confirmed]** Linear uses **two color systems in parallel**: a simple layout-level system (`--bg-*`, `--content-*`) and a richer component-level system (`--color-bg-*`, `--color-text-*`, `--color-border-*`). Episteme should adopt a single unified semantic system.
+- **[confirmed]** Linear dark mode — full palette from CSS inspection (see confirmed values in the Inspiration Sources section above)
+- **[confirmed]** Linear light mode — full palette from CSS inspection (see confirmed values above)
+- **[confirmed]** Linear uses **4 background levels** in dark mode: `#191a22` / `#222430` / `#272937` / `#1b1c27` — plus layout-level `#090909` (sidebar) and `#101012` (content). Episteme likely needs 3–4 levels.
+- **[confirmed]** Accent/focus color: `#575ac6` (a blue-violet)
+- Theming is explicitly deferred. All tokens must be named semantically so they can be remapped when theming is built.
+
+**Tradeoffs to surface**
+- **oklch vs raw hex for token definition**: Linear defines tokens in hex but uses LCH internally for theme generation. For Episteme, defining tokens in `oklch()` in the CSS makes the theming phase easier and values more meaningful. Raw hex is simpler now but opaque. Recommendation: `oklch()`. Get user sign-off.
+- **Accent color**: `#575ac6` is Linear's exact color. Episteme can adopt it (well-tested, distinctive) or choose a differentiating color. Brand decision — present to user with a recommendation.
+- **Number of bg levels**: Linear uses 6 distinct background values. Episteme should rationalize this to a smaller set (3–4 named semantic levels). Propose a mapping during execution.
+
+---
+
+#### Spacing and density
+
+**Questions to answer**
+- What is the named spacing scale and base unit?
+- What are standard control heights (buttons, inputs, menu items, sidebar items)?
+- What is the sidebar width?
+- What are the standard padding values for panels, content areas, and toolbars?
+
+**Inputs**
+- **[confirmed]** Linear blog post references spacer values of 4px, 10px, 12px, 20px, 24px, 56px, 80px, 128px — layout-level spacers. Base unit: 4px.
+- **[confirmed]** Sidebar width: `244px`
+- **[confirmed]** Header/toolbar height: `39px`
+- **[confirmed]** Nav item height: `28px`
+- **[confirmed]** Button height: `28px`, padding: `6px 12px`
+- **[confirmed]** Menu item height: `32px`, padding-left from inner element (not outer container)
+- **[research]** Padding conventions for panels, content areas, and the document reading column — derive from reference app inspection
+
+**Tradeoffs to surface**
+- **Density level**: Desktop tools are meaningfully denser than web apps. Research should establish a specific target control height (e.g., 28px vs 32px) and the execution session should present the tradeoff to the user with visual reference.
+- **Fixed vs fluid sidebar**: Fixed width is simpler to spec and implement. Resizable sidebar is a future enhancement — do not over-engineer for it now.
+
+---
+
+#### Border radius
+
+**Questions to answer**
+- What is the named radius scale and what pixel values?
+- Which radius applies to which component category?
+
+**Inputs**
+- **[confirmed]** Linear's `--control-border-radius: 4px` — applies to buttons, inputs, and controls
+- **[confirmed]** Linear blog post references 8px and 16px for image/asset containers (larger layout elements)
+- **[research]** Radii for menus, dialogs, cards, and badges — not directly confirmed from CSS inspection; derive from reference app inspection and propose a scale
+
+**Tradeoffs to surface**
+- A differentiated scale (small for controls, larger for dialogs) creates visual hierarchy. A uniform scale is simpler but flatter. Research should inform the proposal; user signs off on the scale.
+
+---
+
+#### Shadow and elevation
+
+**Questions to answer**
+- What named elevation levels are needed?
+- What are the CSS `box-shadow` values for each level in dark and light modes?
+- How is elevation communicated in dark mode where shadows are less visible?
+
+**Inputs**
+- **[confirmed]** Linear context menus in dark mode: `box-shadow: none` — elevation is communicated entirely through background color contrast (`#222430` menu surface over `#101012` content background)
+- **[confirmed]** Linear uses 4–6 distinct background color levels to create elevation hierarchy without shadows in dark mode
+- **[research]** Linear's shadow values for light mode and for dialogs/modals — not confirmed; inspect via CSS or derive from reference apps
+- **[research]** Whether any elevated elements (dialogs, tooltips) use shadows in dark mode — likely yes for modals, but not confirmed
+
+**Tradeoffs to surface**
+- In dark mode, `box-shadow` on dark backgrounds is often invisible. Linear's approach (background color steps only, no shadow) is clean but requires sufficient contrast between levels. An alternative complement is `inset 0 0 0 1px` border-via-shadow, which remains visible regardless of background. Present the approach to the user.
+
+---
+
+#### Motion
+
+**Questions to answer**
+- What duration tokens are needed and what values?
+- What easing curves for entering, exiting, and transitioning elements?
+- What interactions should have transitions vs be instant?
+
+**Inputs**
+- **[confirmed]** Linear's philosophy: transitions are intentional and subtle — "spatial context, not attention-drawing." Source: blog post.
+- **[confirmed]** Linear's duration tokens from CSS: `0s` (instant), `0.1s` (fast), `0.15s` (normal), `0.25s` (slow), `0.35s` (deliberate)
+- **[research]** Which elements use which durations, and what easing curves — not confirmed from CSS inspection; derive from reference app observation and desktop convention
+
+**Tradeoffs to surface**
+- Less motion is generally better for a focused desktop tool. The execution session should have a strong bias toward fewer, faster transitions. Present a minimal set of duration tokens to the user (e.g., instant, fast, normal) rather than a large scale.
+
+---
+
+#### Window chrome
+
+**Questions to answer**
+- Exact `tauri.conf.json` configuration for macOS title bar?
+- How is the drag region implemented?
+- What is the title bar height and content layout?
+- What is the Windows frame strategy and what controls does it include?
+- How does the custom title bar interact with the sidebar (does the sidebar extend behind the traffic lights area)?
+
+**Inputs**
+- Tauri v2 supports `titleBarStyle: "Overlay"` — removes the system title bar background; web content fills the full window including the title bar area; native traffic lights remain and are positioned at approximately (13px from left, 13px from top)
+- The draggable region is defined in CSS with `-webkit-app-region: drag`; interactive elements within it must be explicitly marked `-webkit-app-region: no-drag`
+- Standard title bar height: 52px is a common comfortable value; the 38px at the top is the "hidden" title bar area where traffic lights live
+- Linear's title bar: the sidebar header (workspace name + nav controls) extends into the title bar area, with traffic lights floating over the leftmost portion of the sidebar
+- For Windows (Phase 2): `decorations: false` removes the OS frame entirely; custom close/minimize/maximize buttons are rendered in React, positioned top-right, and call Tauri's window management API
+- Platform detection is required to render the correct chrome per OS
+
+**Pre-decided**
+- Settings and all overlay experiences are **in-app panels, not separate OS windows**. This is resolved — not an open question.
+
+---
+
+#### Settings and navigation experience
+
+**Questions to answer**
+- What is the visual design of the settings "mode"?
+- How does the sidebar transform when in settings mode?
+- How does the main content area transform?
+- How does the user return to the main experience?
+
+**Pre-decided (do not re-open)**
+The settings experience follows the Linear pattern precisely:
+- Settings replaces the main content pane — it is not a dialog or overlay; it feels like the app navigated to a new place
+- The sidebar transforms into a settings navigation menu showing settings categories
+- A "Back to app" link with a left chevron appears at the top of the sidebar
+- Closing/exiting settings returns both sidebar and content area to their previous state
+- This same "full app takeover" navigation pattern applies to all overlay experiences — not just settings
+
+The execution session should design the visual specifics of this pattern (typography, spacing, transition behavior) but not re-examine whether to use this pattern.
+
+---
+
+#### Core component patterns
+
+For each component below, the execution session must define: visual appearance, all relevant states (default, hover, focus, active, disabled), dimensions (height, padding, radius), and token references for every visual property. No undocumented values.
+
+Components to specify:
+
+- **Sidebar** — width, item height, section header treatment, icon sizing, selected/hover/active states, folder expand/collapse behavior
+- **Title bar** — height, content layout (traffic lights zone, workspace label, right-side controls), drag region boundaries
+- **Toolbar** — height, button sizing, mode-awareness (formatting tools visible only in edit mode), separator treatment
+- **Buttons** — primary, secondary, ghost, destructive variants; all states; dimensions; icon+label layout
+- **Inputs** — text input, height, border treatment, focus ring, placeholder style, error state
+- **Dialogs and modals** — all in-app (not OS windows); backdrop treatment, container dimensions, header/body/footer layout, close behavior
+- **Context menus and popovers** — width constraints, item height, keyboard shortcut label alignment, separator treatment, nested menu indicator
+- **Badges and tags** — height, radius, typography, color variants (status colors, neutral)
+- **Frontmatter bar** — replaces current `FrontmatterBar.tsx` design; key/value display, layout, truncation behavior
+
+**shadcn strategy (resolve during execution)**
+
+Currently zero shadcn components exist in the codebase. The execution session should recommend and get sign-off on one of these approaches:
+
+- **Option A: Radix UI primitives only** — use `@radix-ui/*` packages directly for accessible primitives (dialog, popover, dropdown-menu, etc.), apply all styling from scratch using design tokens. Maximum control, no visual defaults to fight.
+- **Option B: shadcn/ui with full visual override** — generate shadcn components into `src/components/ui/`, replace all visual styling with design tokens. Keeps Radix under the hood, familiar pattern, but ships with default styles that must be stripped.
+- **Option C: No component library** — build all primitives from scratch including accessibility. Maximum control, highest effort, accessibility risk.
+
+Recommendation to present: Option A. The design system's density and visual style will require overriding essentially all of shadcn's defaults anyway, and going directly to Radix avoids the overhead of fighting generated code.
+
+---
+
+### Kitchen sink preview
+
+The execution session should specify (and the implementation should build) a dev-only kitchen sink view accessible in the Tauri dev build. It must render:
+
+- All color tokens as labeled swatches (background levels, text samples, border samples, accent, state colors) for both dark and light modes
+- Complete type scale — every size with its name, pixel value, and a sample sentence
+- Spacing scale — visual ruler showing each named spacing value
+- All button variants and states
+- Input states (default, focused, error, disabled)
+- Badge and tag variants
+- Sample sidebar (static, not functional)
+- Sample dialog (triggered by a button)
+- Sample context menu
+
+The purpose is to allow the user to review and sign off on the design system as rendered in the actual app before any component migration begins. It is removed or hidden behind a dev flag before production.
+
+## Tech spec
+
+### Scope boundary
+
+This feature produces the design system specification. It does not implement any code changes — those are covered by follow-on enhancements. The boundary: after this feature ships, `design-system.md` is complete and authoritative. Every downstream decision (token encoding, title bar, component migration, kitchen sink) has a clear spec to implement against.
+
+### Output artifacts
+
+**Primary output:**
+- `.eng-docs/wiki/design-system.md` — complete rewrite of the current stub; the canonical design system reference
+
+**Secondary output — documentation cleanup:**
+- `.eng-docs/specs/app.md` — the "Design guidance" section contains placeholder content that predates this feature; simplify it to a single line pointing to `design-system.md` as the canonical source
+
+### Follow-on enhancements (not in scope here)
+
+The following are expected follow-on enhancements, in rough implementation order:
+
+1. **Encode design tokens** — `src/app.css` `@theme {}` block implementing all tokens from `design-system.md`
+2. **Kitchen sink** — dev-only preview view; depends on token encoding being complete before it renders meaningfully
+3. **macOS title bar** — `tauri.conf.json` + `TitleBar.tsx`; retire the separate settings OS window
+4. **Component migrations** — per-component-area enhancements (sidebar, toolbar, buttons, inputs, dialogs, etc.)
+
+Each of these should be planned as its own enhancement spec referencing this feature.
+
+### Enforcement
+
+`design-system.md` is enforced as the canonical design reference via the planning skill's prerequisite check — every design spec stage verifies that the wiki document exists and is consulted before proceeding. No additional ADR is needed.
+
+### Definition of done
+
+- `design-system.md` is complete: all token categories defined with specific values, all core component patterns specified, no undocumented values
+- `app.md` Design guidance section simplified to redirect to `design-system.md`
+
+## Task list
+
+This task list is the execution workflow for the session that produces `design-system.md`. It is structured as four phases. Each phase must complete before the next begins.
+
+> **Sign-off principle**: The user does not need to approve every individual token value. If a system or rule is approved (e.g., "secondary text is always the tertiary text color"), that rule can be applied to all derived values without individual sign-off. Sign-off is required for systems, rules, and any value that involves a real judgment call or brand decision.
+
+---
+
+### Phase 1: Preparation
+
+**Goal**: Ensure the execution session starts with no ambiguities and a deep understanding of what good looks like.
+
+**1.1 — Review spec and close open questions**
+
+- *Description*: Read `feature-design-system.md` in full. Identify any remaining ambiguities, missing context, or decisions that need user input before design work begins. Interview the user to resolve them. Do not proceed to Phase 2 until all blockers are resolved.
+- *Acceptance criteria*: Every decision area in the design spec has either confirmed inputs or a clear plan for how to derive the answer during research. No ambiguities remain that would block a recommendation.
+- *Dependencies*: None
+
+**1.2 — Ground understanding of design system quality**
+
+- *Description*: Before researching reference apps, build a strong internal model of what separates a good design system from a mediocre one. This includes: token naming conventions (semantic vs descriptive), documentation clarity, accessibility requirements (contrast ratios, focus states), how tokens should be structured to support future theming, and common failure modes (too many tokens, too few, wrong abstraction level). Also internalize the pre-decided patterns from this spec: the Linear-style settings/navigation experience, the in-app overlay principle, and the confirmed Linear values.
+- *Acceptance criteria*: The session can articulate why specific token decisions are good or bad, not just what Linear does. Confirmed Linear values are internalized and will be referenced directly rather than re-researched.
+- *Dependencies*: 1.1
+
+---
+
+### Phase 2: Research
+
+**Goal**: Extract design principles from secondary reference apps to validate and supplement the confirmed Linear data.
+
+**2.1 — Inspect secondary reference apps**
+
+- *Description*: Run Raycast, Things 3, Bear, Arc, and Craft. Use Digital Color Meter to sample key colors (background levels, text colors, accent). Use Accessibility Inspector to measure key element dimensions (sidebar item height, control heights, sidebar width). Focus on areas where these apps cover ground Linear doesn't: Bear and Craft for document reading typography, Arc for window chrome integration, Things 3 and Raycast for sidebar density and compact UI. Ask the user for help if any additional CSS inspection or app access is needed.
+- *Acceptance criteria*: For each reference app, at least the following is captured: primary background color, sidebar background, accent color, sidebar item height, and any notable design choices that differ from or complement Linear.
+- *Dependencies*: 1.2
+
+**2.2 — Identify cross-app patterns and divergences**
+
+- *Description*: Synthesize the research. Note which of Linear's choices are consistent across all reference apps (strong signal), which are unique to Linear (weaker signal, may reflect Linear's specific brand), and which reference apps make choices that might be better suited to Episteme's use case. Document findings as inputs to Phase 3.
+- *Acceptance criteria*: A clear synthesis exists: "these Linear choices are validated by other apps; these are Linear-specific; these alternatives from other apps are worth considering for Episteme."
+- *Dependencies*: 2.1
+
+---
+
+### Phase 3: Design decisions — tokens
+
+**Goal**: Produce approved decisions for every token category. Work through one category at a time. For each: present a recommendation with rationale and references, surface tradeoffs, get sign-off before moving on.
+
+**3.1 — Typography**
+
+- *Description*: Present recommendation for: font family (Inter Variable + fallback stack), UI type scale (sizes, weights, line heights for each context), and document content type scale. Reference confirmed Linear values and secondary research. Note the Berkeley Mono question (paid license) and present alternatives.
+- *Acceptance criteria*: Font family approved. Complete UI type scale approved with named tokens. Document content type scale approved with named tokens. Berkeley Mono decision resolved.
+- *Dependencies*: 2.2
+
+**3.2 — Color tokens**
+
+- *Description*: Present recommendation for: color space (oklch vs hex), semantic token structure (number of bg/text/border levels), complete dark mode palette with specific values, complete light mode palette, and accent color. Reference confirmed Linear hex values and propose oklch equivalents. For accent color: present Linear's `#575ac6` as the starting recommendation with a note that this is a brand decision.
+- *Acceptance criteria*: Color space approved. Token structure approved (number of levels, naming convention). Dark mode palette approved. Light mode palette approved. Accent color approved.
+- *Dependencies*: 3.1
+
+**3.3 — Spacing and density**
+
+- *Description*: Present recommendation for: named spacing scale (base unit + all named steps), standard control heights, sidebar width, and standard padding values for panels and content areas. Reference confirmed Linear measurements.
+- *Acceptance criteria*: Spacing scale approved with named tokens and px values. All control heights approved. Sidebar width approved. Panel and content padding approved.
+- *Dependencies*: 3.2
+
+**3.4 — Border radius**
+
+- *Description*: Present recommendation for a named radius scale: which values, which components use which level. Reference confirmed `4px` control radius from Linear and propose the full scale.
+- *Acceptance criteria*: Complete radius scale approved with named tokens, px values, and component assignment.
+- *Dependencies*: 3.3
+
+**3.5 — Shadow and elevation**
+
+- *Description*: Present recommendation for: elevation levels (how many, what they represent), shadow values for light mode, and the dark mode elevation approach (color contrast vs shadow vs border-via-shadow). Reference confirmed finding that Linear uses no shadow in dark mode menus.
+- *Acceptance criteria*: Elevation levels and their names approved. Dark mode elevation approach approved. Light mode shadow values approved.
+- *Dependencies*: 3.4
+
+**3.6 — Motion**
+
+- *Description*: Present recommendation for: duration tokens (mapped from confirmed Linear values: `0s`, `0.1s`, `0.15s`, `0.25s`, `0.35s`), easing curves, and a clear rule for which interactions animate vs are instant.
+- *Acceptance criteria*: Duration tokens approved with names and values. Easing curves approved. Interaction/instant rule approved.
+- *Dependencies*: 3.5
+
+---
+
+### Phase 4: Design decisions — components and shadcn
+
+**Goal**: Produce approved component pattern specs for every component category.
+
+**4.1 — shadcn/Radix strategy**
+
+- *Description*: Present the three options (Radix UI primitives directly / shadcn with full visual override / build from scratch) with honest tradeoffs. Make a recommendation. Resolve this before speccing components, since the answer affects how component patterns are documented.
+- *Acceptance criteria*: Strategy approved.
+- *Dependencies*: 3.6
+
+**4.2 — Window chrome**
+
+- *Description*: Present the macOS title bar design: height, content layout (traffic lights zone, workspace label, right-side controls), drag region boundaries, and how the sidebar header relates to the title bar area. Reference confirmed Linear header height (`39px`) and the Tauri `titleBarStyle: "Overlay"` mechanism. Also document the Windows strategy at a high level for future reference.
+- *Acceptance criteria*: Title bar height and layout approved. Drag region approach approved. Windows strategy noted.
+- *Dependencies*: 4.1
+
+**4.3 — Settings and navigation experience**
+
+- *Description*: The pattern is pre-decided (see Design spec section). This task designs the visual specifics: typography and spacing for the settings navigation sidebar, transition behavior when entering/exiting settings mode, and the "Back to app" treatment. Present with references to the Linear implementation.
+- *Acceptance criteria*: Settings mode visual design approved. Transition behavior approved. "Back to app" treatment approved.
+- *Dependencies*: 4.2
+
+**4.4 — Core components**
+
+- *Description*: Work through each component in turn, presenting a complete spec (visual appearance, all states, dimensions, token references) and getting sign-off before moving to the next. Components: sidebar, toolbar, buttons (all variants), inputs, dialogs/modals, context menus/popovers, badges/tags, frontmatter bar. Use the sign-off principle — if a pattern generalizes (e.g., all hover states use the same token), establish the rule once rather than approving each instance.
+- *Acceptance criteria*: Every component in the list has an approved spec with no undocumented values.
+- *Dependencies*: 4.3
+
+---
+
+### Phase 5: Write design-system.md
+
+**5.1 — Produce design-system.md**
+
+- *Description*: Write the complete `design-system.md` wiki document incorporating all approved decisions from Phases 3 and 4. Structure: token reference (all categories with named tokens, values, and usage notes), component patterns (one section per component), Tailwind v4 encoding guide (how tokens map to the `@theme {}` block), and a brief section on what follow-on enhancements implement.
+- *Acceptance criteria*: `design-system.md` contains every token with a specific value. Every component pattern is fully specified. An engineer can implement any component using only this document.
+- *Dependencies*: 4.4
+
+**5.2 — Update app.md**
+
+- *Description*: Simplify the "Design guidance" section in `app.md` to a single redirect: "See `.eng-docs/wiki/design-system.md` for the canonical design system reference."
+- *Acceptance criteria*: `app.md` Design guidance section no longer contains design values; it points to `design-system.md`.
+- *Dependencies*: 5.1


### PR DESCRIPTION
Adds all untracked planning documents to the repo.

**Design system feature and enhancements** (refs #30):
- `feature-design-system.md`
- `enhancement-encode-design-tokens.md` (refs #31)
- `enhancement-design-kitchen-sink.md` (refs #32)
- `enhancement-macos-title-bar.md` (refs #33)
- `enhancement-migrate-sidebar.md` (refs #34)
- `enhancement-migrate-toolbar.md` (refs #35)
- `enhancement-migrate-interactive-components.md` (refs #36)
- `enhancement-migrate-overlays.md` (refs #37)
- `enhancement-migrate-document-area.md` (refs #38)
- `enhancement-migrate-ai-chat.md` (refs #39)

**Other specs and ADRs:**
- `enhancement-authoring-skill-picker.md`
- `enhancement-chat-box-expansion.md`
- `enhancement-settings-panel.md`
- `adr-009-keyboard-shortcuts.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)