### PR TITLE
docs: add YAML frontmatter to all eng-docs files

### DIFF
--- a/.eng-docs/adrs/adr-001-tauri-desktop-framework.md
+++ b/.eng-docs/adrs/adr-001-tauri-desktop-framework.md
@@ -1,3 +1,11 @@
+---
+created: 2026-03-04
+last_updated: 2026-03-04
+status: accepted
+decided_by: markdstafford
+superseded_by: null
+---
+
 # ADR 001: Tauri desktop framework
 
 ## Status

--- a/.eng-docs/adrs/adr-002-tiptap-document-editor.md
+++ b/.eng-docs/adrs/adr-002-tiptap-document-editor.md
@@ -1,3 +1,11 @@
+---
+created: 2026-03-04
+last_updated: 2026-03-04
+status: accepted
+decided_by: markdstafford
+superseded_by: null
+---
+
 # ADR 002: TipTap document editor
 
 ## Status

--- a/.eng-docs/adrs/adr-003-zustand-state-management.md
+++ b/.eng-docs/adrs/adr-003-zustand-state-management.md
@@ -1,3 +1,11 @@
+---
+created: 2026-03-04
+last_updated: 2026-03-04
+status: accepted
+decided_by: markdstafford
+superseded_by: null
+---
+
 # ADR 003: Zustand state management
 
 ## Status

--- a/.eng-docs/adrs/adr-004-tailwind-css-styling.md
+++ b/.eng-docs/adrs/adr-004-tailwind-css-styling.md
@@ -1,3 +1,11 @@
+---
+created: 2026-03-04
+last_updated: 2026-03-04
+status: accepted
+decided_by: markdstafford
+superseded_by: null
+---
+
 # ADR 004: Tailwind CSS styling
 
 ## Status

--- a/.eng-docs/adrs/adr-005-github-oauth-authentication.md
+++ b/.eng-docs/adrs/adr-005-github-oauth-authentication.md
@@ -1,3 +1,11 @@
+---
+created: 2026-03-04
+last_updated: 2026-03-04
+status: accepted
+decided_by: markdstafford
+superseded_by: null
+---
+
 # ADR 005: GitHub OAuth authentication
 
 ## Status

--- a/.eng-docs/adrs/adr-006-zod-validation.md
+++ b/.eng-docs/adrs/adr-006-zod-validation.md
@@ -1,3 +1,11 @@
+---
+created: 2026-03-04
+last_updated: 2026-03-04
+status: accepted
+decided_by: markdstafford
+superseded_by: null
+---
+
 # ADR 006: Zod validation
 
 ## Status

--- a/.eng-docs/adrs/adr-007-vitest-playwright-testing.md
+++ b/.eng-docs/adrs/adr-007-vitest-playwright-testing.md
@@ -1,3 +1,11 @@
+---
+created: 2026-03-04
+last_updated: 2026-03-04
+status: accepted
+decided_by: markdstafford
+superseded_by: null
+---
+
 # ADR 007: Vitest and Playwright testing strategy
 
 ## Status

--- a/.eng-docs/adrs/adr-008-claude-skills-document-types.md
+++ b/.eng-docs/adrs/adr-008-claude-skills-document-types.md
@@ -1,3 +1,11 @@
+---
+created: 2026-03-04
+last_updated: 2026-03-04
+status: accepted
+decided_by: markdstafford
+superseded_by: null
+---
+
 # ADR 008: Claude skills pattern for document types
 
 ## Status

--- a/.eng-docs/adrs/adr-009-keyboard-shortcuts.md
+++ b/.eng-docs/adrs/adr-009-keyboard-shortcuts.md
@@ -1,3 +1,11 @@
+---
+created: 2026-03-10
+last_updated: 2026-03-10
+status: accepted
+decided_by: markdstafford
+superseded_by: null
+---
+
 # ADR-009: Keyboard shortcuts strategy
 
 ## Status

--- a/.eng-docs/specs/app.md
+++ b/.eng-docs/specs/app.md
@@ -1,3 +1,8 @@
+---
+created: 2026-03-04
+last_updated: 2026-03-10
+---
+
 # Episteme
 
 ## What

--- a/.eng-docs/specs/enhancement-authoring-skill-picker.md
+++ b/.eng-docs/specs/enhancement-authoring-skill-picker.md
@@ -1,3 +1,13 @@
+---
+created: 2026-03-10
+last_updated: 2026-03-10
+status: complete
+issue: 14
+specced_by: markdstafford
+implemented_by: markdstafford
+superseded_by: null
+---
+
 # Enhancement: Authoring Skill Picker
 
 ## Parent feature

--- a/.eng-docs/specs/enhancement-chat-box-expansion.md
+++ b/.eng-docs/specs/enhancement-chat-box-expansion.md
@@ -1,3 +1,13 @@
+---
+created: 2026-03-10
+last_updated: 2026-03-10
+status: draft
+issue: 8
+specced_by: markdstafford
+implemented_by: null
+superseded_by: null
+---
+
 # Enhancement: Chat Box Expansion
 
 ## Parent feature

--- a/.eng-docs/specs/enhancement-design-kitchen-sink.md
+++ b/.eng-docs/specs/enhancement-design-kitchen-sink.md
@@ -1,3 +1,13 @@
+---
+created: 2026-03-10
+last_updated: 2026-03-11
+status: complete
+issue: 32
+specced_by: markdstafford
+implemented_by: markdstafford
+superseded_by: null
+---
+
 # Enhancement: Design kitchen sink
 
 ## Parent feature

--- a/.eng-docs/specs/enhancement-encode-design-tokens.md
+++ b/.eng-docs/specs/enhancement-encode-design-tokens.md
@@ -1,3 +1,13 @@
+---
+created: 2026-03-10
+last_updated: 2026-03-10
+status: complete
+issue: 31
+specced_by: markdstafford
+implemented_by: markdstafford
+superseded_by: null
+---
+
 # Enhancement: Encode design tokens
 
 ## Parent feature

--- a/.eng-docs/specs/enhancement-macos-title-bar.md
+++ b/.eng-docs/specs/enhancement-macos-title-bar.md
@@ -1,3 +1,13 @@
+---
+created: 2026-03-10
+last_updated: 2026-03-10
+status: draft
+issue: 33
+specced_by: markdstafford
+implemented_by: null
+superseded_by: null
+---
+
 # Enhancement: macOS title bar
 
 ## Parent feature

--- a/.eng-docs/specs/enhancement-migrate-ai-chat.md
+++ b/.eng-docs/specs/enhancement-migrate-ai-chat.md
@@ -1,3 +1,13 @@
+---
+created: 2026-03-10
+last_updated: 2026-03-10
+status: draft
+issue: 39
+specced_by: markdstafford
+implemented_by: null
+superseded_by: null
+---
+
 # Enhancement: Migrate AI chat panel to design system
 
 ## Parent feature

--- a/.eng-docs/specs/enhancement-migrate-document-area.md
+++ b/.eng-docs/specs/enhancement-migrate-document-area.md
@@ -1,3 +1,13 @@
+---
+created: 2026-03-10
+last_updated: 2026-03-10
+status: draft
+issue: 38
+specced_by: markdstafford
+implemented_by: null
+superseded_by: null
+---
+
 # Enhancement: Migrate document area to design system
 
 ## Parent feature

--- a/.eng-docs/specs/enhancement-migrate-interactive-components.md
+++ b/.eng-docs/specs/enhancement-migrate-interactive-components.md
@@ -1,3 +1,13 @@
+---
+created: 2026-03-10
+last_updated: 2026-03-10
+status: draft
+issue: 36
+specced_by: markdstafford
+implemented_by: null
+superseded_by: null
+---
+
 # Enhancement: Migrate interactive components to design system
 
 ## Parent feature

--- a/.eng-docs/specs/enhancement-migrate-overlays.md
+++ b/.eng-docs/specs/enhancement-migrate-overlays.md
@@ -1,3 +1,13 @@
+---
+created: 2026-03-10
+last_updated: 2026-03-10
+status: draft
+issue: 37
+specced_by: markdstafford
+implemented_by: null
+superseded_by: null
+---
+
 # Enhancement: Migrate overlays to design system
 
 ## Parent feature

--- a/.eng-docs/specs/enhancement-migrate-sidebar.md
+++ b/.eng-docs/specs/enhancement-migrate-sidebar.md
@@ -1,3 +1,13 @@
+---
+created: 2026-03-10
+last_updated: 2026-03-10
+status: draft
+issue: 34
+specced_by: markdstafford
+implemented_by: null
+superseded_by: null
+---
+
 # Enhancement: Migrate sidebar to design system
 
 ## Parent feature

--- a/.eng-docs/specs/enhancement-migrate-toolbar.md
+++ b/.eng-docs/specs/enhancement-migrate-toolbar.md
@@ -1,3 +1,13 @@
+---
+created: 2026-03-10
+last_updated: 2026-03-10
+status: draft
+issue: 35
+specced_by: markdstafford
+implemented_by: null
+superseded_by: null
+---
+
 # Enhancement: Migrate toolbar to design system
 
 ## Parent feature

--- a/.eng-docs/specs/enhancement-settings-panel.md
+++ b/.eng-docs/specs/enhancement-settings-panel.md
@@ -1,3 +1,13 @@
+---
+created: 2026-03-10
+last_updated: 2026-03-10
+status: draft
+issue: null
+specced_by: markdstafford
+implemented_by: null
+superseded_by: null
+---
+
 # Enhancement: Settings panel
 
 ## Parent feature

--- a/.eng-docs/specs/enhancement-sidebar-folder-name.md
+++ b/.eng-docs/specs/enhancement-sidebar-folder-name.md
@@ -1,3 +1,13 @@
+---
+created: 2026-03-08
+last_updated: 2026-03-08
+status: complete
+issue: 7
+specced_by: markdstafford
+implemented_by: markdstafford
+superseded_by: null
+---
+
 # Enhancement: Sidebar Folder Name
 
 ## Goals

--- a/.eng-docs/specs/feature-ai-chat-assistant.md
+++ b/.eng-docs/specs/feature-ai-chat-assistant.md
@@ -1,3 +1,13 @@
+---
+created: 2026-03-04
+last_updated: 2026-03-04
+status: complete
+issue: null
+specced_by: markdstafford
+implemented_by: markdstafford
+superseded_by: null
+---
+
 # AI Chat Assistant
 
 ## What

--- a/.eng-docs/specs/feature-baseline-app.md
+++ b/.eng-docs/specs/feature-baseline-app.md
@@ -1,3 +1,13 @@
+---
+created: 2026-03-04
+last_updated: 2026-03-04
+status: complete
+issue: null
+specced_by: markdstafford
+implemented_by: markdstafford
+superseded_by: null
+---
+
 # Feature: Baseline Desktop App
 
 ## What

--- a/.eng-docs/specs/feature-design-system.md
+++ b/.eng-docs/specs/feature-design-system.md
@@ -1,3 +1,13 @@
+---
+created: 2026-03-10
+last_updated: 2026-03-10
+status: complete
+issue: 30
+specced_by: markdstafford
+implemented_by: markdstafford
+superseded_by: null
+---
+
 # Feature: Design system
 
 ## What

--- a/.eng-docs/specs/feature-document-authoring.md
+++ b/.eng-docs/specs/feature-document-authoring.md
@@ -1,3 +1,13 @@
+---
+created: 2026-03-04
+last_updated: 2026-03-08
+status: implementing
+issue: 13
+specced_by: markdstafford
+implemented_by: null
+superseded_by: null
+---
+
 # Document Authoring with AI
 
 ## What

--- a/.eng-docs/specs/feature-markdown-rendering.md
+++ b/.eng-docs/specs/feature-markdown-rendering.md
@@ -1,3 +1,13 @@
+---
+created: 2026-03-04
+last_updated: 2026-03-04
+status: complete
+issue: null
+specced_by: markdstafford
+implemented_by: markdstafford
+superseded_by: null
+---
+
 # Feature: Markdown Rendering
 
 ## What

--- a/.eng-docs/specs/feature-open-folder.md
+++ b/.eng-docs/specs/feature-open-folder.md
@@ -1,3 +1,13 @@
+---
+created: 2026-03-04
+last_updated: 2026-03-04
+status: complete
+issue: null
+specced_by: markdstafford
+implemented_by: markdstafford
+superseded_by: null
+---
+
 # Feature: Open Folder
 
 ## What

--- a/.eng-docs/specs/feature-sidebar-browser.md
+++ b/.eng-docs/specs/feature-sidebar-browser.md
@@ -1,3 +1,13 @@
+---
+created: 2026-03-04
+last_updated: 2026-03-04
+status: complete
+issue: null
+specced_by: markdstafford
+implemented_by: markdstafford
+superseded_by: null
+---
+
 # Feature: Sidebar File Browser
 
 ## What

--- a/.eng-docs/wiki/api-contracts.md
+++ b/.eng-docs/wiki/api-contracts.md
@@ -1,3 +1,9 @@
+---
+created: 2026-03-04
+last_updated: 2026-03-04
+status: stub
+---
+
 # API Contracts
 
 This document defines API endpoints, request/response schemas, and contracts for Episteme.

--- a/.eng-docs/wiki/database-schema.md
+++ b/.eng-docs/wiki/database-schema.md
@@ -1,3 +1,9 @@
+---
+created: 2026-03-04
+last_updated: 2026-03-04
+status: stub
+---
+
 # Database Schema
 
 This document defines database tables, columns, relationships, and constraints for Episteme.

--- a/.eng-docs/wiki/design-system.md
+++ b/.eng-docs/wiki/design-system.md
@@ -1,3 +1,9 @@
+---
+created: 2026-03-04
+last_updated: 2026-03-10
+status: active
+---
+
 # Design System
 
 Episteme's canonical design reference. Every color, spacing value, type size, radius, shadow, and motion token is defined here. Every core component pattern is fully specified. An engineer implementing a new component should be able to do so using only this document, with no follow-up questions.

--- a/.eng-docs/wiki/domain-model.md
+++ b/.eng-docs/wiki/domain-model.md
@@ -1,3 +1,9 @@
+---
+created: 2026-03-04
+last_updated: 2026-03-04
+status: active
+---
+
 # Domain Model
 
 This document defines the core domain entities, their relationships, and business rules for Episteme.


### PR DESCRIPTION
## Summary

- Adds YAML frontmatter to all 34 files in `.eng-docs/` (9 ADRs, 1 app spec, 7 feature specs, 13 enhancement specs, 4 wiki docs)
- Schema is tailored by file type: ADRs track `status/decided_by/superseded_by`; features/enhancements track `status/issue/specced_by/implemented_by/superseded_by`; wiki docs track `status` (`stub|active`)
- All person fields support lists; all files have `created` and `last_updated` dates sourced from git history

## Test plan

- [ ] Spot-check a few files in each category to confirm frontmatter is present and values look correct
- [ ] Verify no non-`.eng-docs` files were modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)