### PR TITLE
docs: mark enhancement-badge-primitive complete

### DIFF
--- a/.eng-docs/specs/enhancement-badge-primitive.md
+++ b/.eng-docs/specs/enhancement-badge-primitive.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-03-12
 last_updated: 2026-03-12
-status: implementing
+status: complete
 issue: 48
 specced_by: markdstafford
 implemented_by: markdstafford


### PR DESCRIPTION
Sets `status: complete` in the Badge primitive spec frontmatter following merge of PR #61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)