### PR TITLE
fix: keyboard reachability, focus indicators, and semantic HTML

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -159,10 +159,6 @@
 }
 
 @layer components {
-  .titlebar-btn:hover:not(:disabled) {
-    background: var(--color-bg-hover);
-  }
-
   [data-ui-input]::placeholder {
     color: var(--color-text-tertiary);
   }

--- a/src/components/CreateNewDialog.tsx
+++ b/src/components/CreateNewDialog.tsx
@@ -168,25 +168,16 @@ export function CreateNewDialog({
                 key={opt.skillName ?? "other"}
                 data-option="true"
                 onClick={() => handleSelect(opt)}
+                className="focus-ring hover:bg-(--color-bg-hover) rounded-[var(--radius-md)] transition-colors duration-(--duration-fast)"
                 style={{
                   display: "flex",
                   alignItems: "center",
                   gap: 12,
                   width: "100%",
                   padding: "var(--space-2) var(--space-3)",
-                  borderRadius: "var(--radius-md)",
-                  background: "transparent",
                   border: "none",
                   cursor: "pointer",
                   textAlign: "left",
-                  transition: `background-color var(--duration-fast)`,
-                }}
-                onMouseEnter={(e) => {
-                  (e.currentTarget as HTMLElement).style.backgroundColor =
-                    "var(--color-bg-hover)";
-                }}
-                onMouseLeave={(e) => {
-                  (e.currentTarget as HTMLElement).style.backgroundColor = "";
                 }}
               >
                 <span style={{ flexShrink: 0 }}>

--- a/src/components/FileTree.tsx
+++ b/src/components/FileTree.tsx
@@ -57,6 +57,14 @@ export function FileTree() {
   const focusedPathRef = useRef<string | null>(null);
   const treeRef = useRef<HTMLDivElement>(null);
 
+  // Ensure exactly one item always has tabIndex={0} (roving tabindex)
+  if (focusedPathRef.current === null && nodes.length > 0) {
+    const visiblePaths = getVisiblePaths(nodes, expandedPaths);
+    if (visiblePaths.length > 0) {
+      focusedPathRef.current = visiblePaths[0];
+    }
+  }
+
   const setFocusedPath = useCallback(
     (path: string) => {
       focusedPathRef.current = path;
@@ -169,10 +177,20 @@ export function FileTree() {
     <div
       ref={treeRef}
       role="tree"
+      tabIndex={0}
       onKeyDown={handleKeyDown}
       onFocus={(e) => {
-        const path = (e.target as HTMLElement).dataset?.path;
-        if (path) handleFocus(path);
+        // Only handle focus on the tree root itself, not bubbled from children
+        if (e.target === e.currentTarget) {
+          const visiblePaths = getVisiblePaths(nodes, expandedPaths);
+          const targetPath = focusedPathRef.current && visiblePaths.includes(focusedPathRef.current)
+            ? focusedPathRef.current
+            : visiblePaths[0];
+          if (targetPath) setFocusedPath(targetPath);
+        } else {
+          const path = (e.target as HTMLElement).dataset?.path;
+          if (path) handleFocus(path);
+        }
       }}
     >
       {renderNodes(nodes, 0)}

--- a/src/components/FileTreeItem.tsx
+++ b/src/components/FileTreeItem.tsx
@@ -45,15 +45,11 @@ export function FileTreeItem({
     ? "bg-(--color-bg-hover) text-(--color-text-primary)"
     : "";
 
-  const focusStyles = isFocused
-    ? "outline-2 outline-(--color-accent) outline-offset-2"
-    : "";
-
   return (
     <ContextMenu>
       <ContextMenuTrigger asChild>
         <button
-          className={`group flex items-center gap-2 w-full text-left h-(--height-nav-item) px-[var(--space-2)] text-[length:var(--font-size-ui-lg)] rounded-(--radius-md) cursor-pointer text-(--color-text-secondary) hover:bg-(--color-bg-subtle) hover:text-(--color-text-primary) transition-colors duration-(--duration-fast) ease-(--ease-default) ${selectedStyles} ${focusStyles}`}
+          className={`group flex items-center gap-2 w-full text-left h-(--height-nav-item) px-[var(--space-2)] text-[length:var(--font-size-ui-lg)] rounded-(--radius-md) cursor-pointer text-(--color-text-secondary) hover:bg-(--color-bg-subtle) hover:text-(--color-text-primary) transition-colors duration-(--duration-fast) ease-(--ease-default) focus-ring ${selectedStyles}`}
           style={{ paddingLeft }}
           onClick={handleClick}
           role="treeitem"

--- a/src/components/SettingsNav.tsx
+++ b/src/components/SettingsNav.tsx
@@ -14,7 +14,7 @@ export function SettingsNav() {
       <button
         onClick={closeSettings}
         aria-label="Back to app"
-        className="flex items-center gap-[var(--space-2)] px-[var(--space-2)] h-[var(--height-nav-item)] w-full text-[length:var(--font-size-ui-base)] text-(--color-text-tertiary) hover:text-(--color-text-primary) transition-colors duration-(--duration-fast)"
+        className="flex items-center gap-[var(--space-2)] px-[var(--space-2)] h-[var(--height-nav-item)] w-full text-[length:var(--font-size-ui-base)] text-(--color-text-tertiary) hover:text-(--color-text-primary) transition-colors duration-(--duration-fast) focus-ring"
       >
         <ChevronLeft size={16} />
         Back to app
@@ -27,7 +27,7 @@ export function SettingsNav() {
           <button
             key={cat.id}
             onClick={() => setActiveCategory(cat.id)}
-            className={`group flex items-center gap-[var(--space-2)] px-[var(--space-2)] h-[var(--height-nav-item)] w-full rounded-[var(--radius-md)] text-[length:var(--font-size-ui-lg)] transition-colors duration-(--duration-fast) ${
+            className={`group flex items-center gap-[var(--space-2)] px-[var(--space-2)] h-[var(--height-nav-item)] w-full rounded-[var(--radius-md)] text-[length:var(--font-size-ui-lg)] transition-colors duration-(--duration-fast) focus-ring cursor-pointer ${
               active
                 ? "bg-(--color-bg-hover) text-(--color-text-primary)"
                 : "text-(--color-text-secondary) hover:bg-(--color-bg-subtle) hover:text-(--color-text-primary)"

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -26,14 +26,15 @@ export function Sidebar({ children }: SidebarProps) {
             {folderName && (
               <div
                 data-testid="folder-header"
-                className="px-3 py-2 flex items-center justify-between border-b border-(--color-border-subtle) shrink-0"
+                className="px-3 py-2 flex items-center justify-between border-b border-(--color-border-subtle) shrink-0 cursor-pointer hover:bg-(--color-bg-subtle) rounded"
+                onClick={() => openFolder()}
               >
-                <span
-                  className="text-[length:var(--font-size-ui-xs)] font-medium text-(--color-text-quaternary) truncate min-w-0 cursor-pointer hover:bg-(--color-bg-subtle) rounded"
-                  onClick={() => openFolder()}
+                <button
+                  className="text-[length:var(--font-size-ui-xs)] font-medium text-(--color-text-quaternary) truncate min-w-0 bg-transparent border-none p-0 text-left focus-ring"
+                  tabIndex={-1}
                 >
                   {folderName}
-                </span>
+                </button>
               </div>
             )}
             {children}

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -1,26 +1,12 @@
-import { CSSProperties, useState } from "react";
+import { useState } from "react";
 import { ChevronLeft, ChevronRight, Share2, Plus, Aperture } from "lucide-react";
+import { Button } from "@/components/ui/Button";
 import { CreateNewDialog } from "@/components/CreateNewDialog";
 
 interface TitleBarProps {
   folderPath: string | null;
   onStartAuthoring: (skillName: string | null) => void;
 }
-
-const iconBtnBase: CSSProperties = {
-  width: 28,
-  height: 28,
-  display: "flex",
-  alignItems: "center",
-  justifyContent: "center",
-  background: "transparent",
-  border: "none",
-  borderRadius: "var(--radius-base)",
-  color: "var(--color-text-tertiary)",
-  cursor: "pointer",
-  padding: 0,
-  flexShrink: 0,
-};
 
 export function TitleBar({ folderPath, onStartAuthoring }: TitleBarProps) {
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -55,20 +41,12 @@ export function TitleBar({ folderPath, onStartAuthoring }: TitleBarProps) {
             className="titlebar-no-drag"
             style={{ width: 70, height: "100%", flexShrink: 0 }}
           />
-          <button
-            className="titlebar-btn"
-            style={iconBtnBase}
-            aria-label="Navigate back"
-          >
+          <Button variant="ghost" size="sm" iconOnly aria-label="Navigate back" style={{ color: "var(--color-text-tertiary)" }}>
             <ChevronLeft size={16} />
-          </button>
-          <button
-            className="titlebar-btn"
-            style={iconBtnBase}
-            aria-label="Navigate forward"
-          >
+          </Button>
+          <Button variant="ghost" size="sm" iconOnly aria-label="Navigate forward" style={{ color: "var(--color-text-tertiary)" }}>
             <ChevronRight size={16} />
-          </button>
+          </Button>
         </div>
 
         {/* Section 2: title — flex:1, centered icon + text, entire section is drag region */}
@@ -106,25 +84,20 @@ export function TitleBar({ folderPath, onStartAuthoring }: TitleBarProps) {
             flexShrink: 0,
           }}
         >
-          <button
-            className="titlebar-btn"
-            style={iconBtnBase}
-            aria-label="Share"
-          >
+          <Button variant="ghost" size="sm" iconOnly aria-label="Share" style={{ color: "var(--color-text-tertiary)" }}>
             <Share2 size={16} />
-          </button>
-          <button
-            className="titlebar-btn"
-            style={{
-              ...iconBtnBase,
-              ...(folderPath === null ? { opacity: 0.4, cursor: "not-allowed" } : {}),
-            }}
-            disabled={folderPath === null}
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            iconOnly
             aria-label="New document"
+            disabled={folderPath === null}
             onClick={() => setDialogOpen(true)}
+            style={{ color: "var(--color-text-tertiary)" }}
           >
             <Plus size={16} />
-          </button>
+          </Button>
         </div>
       </div>
       {dialogOpen && folderPath && (

--- a/src/components/ui/Dialog.tsx
+++ b/src/components/ui/Dialog.tsx
@@ -43,7 +43,7 @@ export function DialogContent({
           backgroundColor: "var(--color-bg-elevated)",
           borderRadius: "var(--radius-xl)",
           boxShadow: "var(--shadow-lg)",
-          overflow: "hidden",
+          overflow: "visible",
           zIndex: 50,
           ...style,
         }}


### PR DESCRIPTION
## Summary

- **FileTree**: add `tabIndex={0}` to tree root, auto-focus first/last-focused item on tree entry, initialize roving tabindex so one item always has `tabIndex={0}`; replace `isFocused` outline classes with `.focus-ring` CSS utility in FileTreeItem
- **SettingsNav / CreateNewDialog**: add `focus-ring` class to all interactive elements missing focus indicators; replace imperative hover handlers with CSS `:hover` in CreateNewDialog
- **TitleBar**: refactor 4 raw `<button>` elements to `<Button variant="ghost" size="sm" iconOnly>`, removing ~15 lines of manual `iconBtnBase` styling and the `.titlebar-btn` CSS class
- **Dialog**: change `overflow: hidden` to `overflow: visible` on DialogContent so focus rings aren't clipped
- **Sidebar**: change folder header `<span>` to `<button>` with reset styles, move click handler to row container for full-row hit target, add `focus-ring`

## Test Plan

- [x] All 353 tests pass
- [x] Build succeeds (`npm run build`)
- [x] Only in-scope files modified (8 files, net -25 lines)
- [ ] Tab into file tree → first item focused → arrow keys navigate → Tab leaves tree
- [ ] Settings nav items show focus ring on keyboard focus
- [ ] CreateNewDialog options show focus ring on keyboard focus
- [ ] TitleBar icon buttons show focus ring on keyboard focus
- [ ] Dialog focus rings not clipped by container overflow
- [ ] Sidebar folder header clickable across full row

🤖 Generated with [Claude Code](https://claude.com/claude-code)