### PR TITLE
fix: spec compliance — tokens, padding, transitions, layout, active state

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -90,6 +90,7 @@
 /* Dark mode tokens */
 @layer base {
   :root {
+    font-family: var(--font-ui);
     --color-bg-app: oklch(7% 0.01 264);
     --color-bg-base: oklch(9.5% 0.012 264);
     --color-bg-subtle: oklch(12% 0.015 264);
@@ -161,6 +162,10 @@
 @layer components {
   [data-ui-input]::placeholder {
     color: var(--color-text-tertiary);
+  }
+
+  .context-menu-item {
+    transition: background-color var(--duration-fast), color var(--duration-fast);
   }
 
   /* ContextMenu item highlight — covers both mouse hover and keyboard navigation */

--- a/src/components/DocumentViewer.tsx
+++ b/src/components/DocumentViewer.tsx
@@ -84,7 +84,7 @@ export function DocumentViewer() {
     return (
       <div
         className="flex-1 flex items-center justify-center"
-        style={{ backgroundColor: "var(--color-bg-app)" }}
+        style={{ backgroundColor: "var(--color-bg-base)" }}
       >
         <p style={{ color: "var(--color-text-secondary)", fontSize: "var(--font-size-ui-lg)" }}>
           Select a document from the sidebar
@@ -125,18 +125,14 @@ export function DocumentViewer() {
       style={{ backgroundColor: "var(--color-bg-base)" }}
     >
       {frontmatter && <FrontmatterBar frontmatter={frontmatter} />}
-      <div
-        className="mx-auto"
-        style={{
-          maxWidth: "var(--doc-content-width)",
-          paddingInline: "var(--padding-content)",
-        }}
-      >
-        {content !== null && (
-          <div style={{ fontSize: "var(--font-size-doc-base)", lineHeight: "1.7" }}>
-            <MarkdownRenderer content={content} onLinkClick={handleLinkClick} />
-          </div>
-        )}
+      <div style={{ paddingInline: "var(--padding-content)", paddingBlock: "var(--space-6)" }}>
+        <div className="mx-auto" style={{ maxWidth: "var(--doc-content-width)" }}>
+          {content !== null && (
+            <div style={{ fontSize: "var(--font-size-doc-base)", lineHeight: "1.7" }}>
+              <MarkdownRenderer content={content} onLinkClick={handleLinkClick} />
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -3,6 +3,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { useAiChatStore } from "@/stores/aiChat";
 import { useSettingsStore } from "@/stores/settings";
 import { settingsConfig } from "@/config/settings";
+import { Input } from "@/components/ui/Input";
 
 const AWS_PROFILE_REGEX = /^[A-Za-z0-9_.-]{1,64}$/;
 
@@ -49,13 +50,11 @@ function AwsProfileSetting({ id, label }: { id: string; label: string }) {
       >
         {label}
       </label>
-      <input
+      <Input
         id={id}
         ref={inputRef}
-        type="text"
         value={awsProfile}
         onChange={(e) => handleChange(e.target.value)}
-        className="h-[var(--height-control-base)] px-[10px] text-[length:var(--font-size-ui-base)] bg-(--color-bg-subtle) border border-(--color-border-default) rounded-[var(--radius-base)] text-(--color-text-primary) placeholder:text-(--color-text-tertiary) focus:border-(--color-accent) focus:shadow-[0_0_0_2px_color-mix(in_oklch,var(--color-accent)_25%,transparent)] outline-none transition-[border-color,box-shadow] duration-(--duration-fast)"
         placeholder="e.g. default"
       />
     </div>
@@ -116,7 +115,7 @@ export function SettingsPanel() {
   const activeCategory = useSettingsStore((s) => s.activeCategory);
 
   return (
-    <div className="flex-1 bg-(--color-bg-base) overflow-y-auto p-[var(--padding-content)]">
+    <div className="flex-1 bg-(--color-bg-base) overflow-y-auto px-[var(--padding-content)] pt-[var(--space-6)]">
       <CategoryContent categoryId={activeCategory} />
     </div>
   );

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -41,10 +41,10 @@ export function TitleBar({ folderPath, onStartAuthoring }: TitleBarProps) {
             className="titlebar-no-drag"
             style={{ width: 70, height: "100%", flexShrink: 0 }}
           />
-          <Button variant="ghost" size="sm" iconOnly aria-label="Navigate back" style={{ color: "var(--color-text-tertiary)" }}>
+          <Button variant="ghost" size="sm" iconOnly aria-label="Navigate back" disabled style={{ color: "var(--color-text-tertiary)" }}>
             <ChevronLeft size={16} />
           </Button>
-          <Button variant="ghost" size="sm" iconOnly aria-label="Navigate forward" style={{ color: "var(--color-text-tertiary)" }}>
+          <Button variant="ghost" size="sm" iconOnly aria-label="Navigate forward" disabled style={{ color: "var(--color-text-tertiary)" }}>
             <ChevronRight size={16} />
           </Button>
         </div>
@@ -77,14 +77,16 @@ export function TitleBar({ folderPath, onStartAuthoring }: TitleBarProps) {
         <div
           className="titlebar-no-drag"
           style={{
+            width: 80,
             height: "100%",
             display: "flex",
             alignItems: "center",
+            justifyContent: "flex-end",
             paddingRight: "var(--space-2)",
             flexShrink: 0,
           }}
         >
-          <Button variant="ghost" size="sm" iconOnly aria-label="Share" style={{ color: "var(--color-text-tertiary)" }}>
+          <Button variant="ghost" size="sm" iconOnly aria-label="Share" disabled style={{ color: "var(--color-text-tertiary)" }}>
             <Share2 size={16} />
           </Button>
           <Button

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -39,6 +39,13 @@ const variantHoverStyles: Record<ButtonVariant, string> = {
   destructive: "var(--color-state-danger-hover)",
 };
 
+const variantActiveStyles: Record<ButtonVariant, string> = {
+  primary: "oklch(41% 0.175 230)",
+  secondary: "var(--color-bg-overlay)",
+  ghost: "var(--color-bg-hover)",
+  destructive: "oklch(54% 0.2 25)",
+};
+
 export function Button({
   variant = "secondary",
   size = "base",
@@ -48,10 +55,13 @@ export function Button({
   style,
   onMouseEnter,
   onMouseLeave,
+  onMouseDown,
+  onMouseUp,
   className,
   ...rest
 }: ButtonProps) {
   const [hovered, setHovered] = React.useState(false);
+  const [active, setActive] = React.useState(false);
 
   const isIconOnly =
     iconOnly === true ||
@@ -83,6 +93,9 @@ export function Button({
     ...(hovered && !disabled
       ? { backgroundColor: variantHoverStyles[variant] }
       : {}),
+    ...(active && !disabled
+      ? { backgroundColor: variantActiveStyles[variant] }
+      : {}),
     ...style,
   };
 
@@ -98,7 +111,16 @@ export function Button({
       }}
       onMouseLeave={(e) => {
         setHovered(false);
+        setActive(false);
         onMouseLeave?.(e);
+      }}
+      onMouseDown={(e) => {
+        setActive(true);
+        onMouseDown?.(e);
+      }}
+      onMouseUp={(e) => {
+        setActive(false);
+        onMouseUp?.(e);
       }}
     >
       {children}

--- a/src/components/ui/Dialog.tsx
+++ b/src/components/ui/Dialog.tsx
@@ -128,7 +128,7 @@ export function DialogFooter({ children }: { children: React.ReactNode }) {
         justifyContent: "flex-end",
         alignItems: "center",
         gap: "var(--space-2)",
-        padding: "var(--padding-panel)",
+        padding: "var(--space-4)",
         borderTop: "1px solid var(--color-border-subtle)",
       }}
     >

--- a/tests/unit/DocumentViewer.test.tsx
+++ b/tests/unit/DocumentViewer.test.tsx
@@ -117,7 +117,11 @@ describe("DocumentViewer", () => {
     expect(outer.classList.contains("overflow-y-auto")).toBe(true);
     expect(outer.style.backgroundColor).toBe("var(--color-bg-base)");
 
-    const contentCol = outer.lastElementChild as HTMLElement;
+    // Outer → lastElementChild is padding wrapper → firstElementChild is content column
+    const paddingWrapper = outer.lastElementChild as HTMLElement;
+    expect(paddingWrapper.style.paddingInline).toBe("var(--padding-content)");
+    expect(paddingWrapper.style.paddingBlock).toBe("var(--space-6)");
+    const contentCol = paddingWrapper.firstElementChild as HTMLElement;
     expect(contentCol.style.maxWidth).toBe("var(--doc-content-width)");
     expect(contentCol.classList.contains("mx-auto")).toBe(true);
     expect(contentCol.classList.contains("max-w-4xl")).toBe(false);
@@ -136,7 +140,10 @@ describe("DocumentViewer", () => {
     const outer = container.firstChild as HTMLElement;
     expect(outer.children.length).toBe(2);
     expect(outer.children[0].textContent).toContain("title");
-    expect((outer.children[1] as HTMLElement).style.maxWidth).toBe("var(--doc-content-width)");
+    // children[1] is the padding wrapper; its first child is the content column
+    const paddingWrapper = outer.children[1] as HTMLElement;
+    const contentCol = paddingWrapper.firstElementChild as HTMLElement;
+    expect(contentCol.style.maxWidth).toBe("var(--doc-content-width)");
   });
 
   it("applies doc-scale typography to prose container", async () => {
@@ -148,9 +155,10 @@ describe("DocumentViewer", () => {
       expect(screen.queryByText("Loading document...")).not.toBeInTheDocument();
     });
 
-    // Outer → lastElementChild is content column → firstElementChild is prose wrapper
+    // Outer → lastElementChild is padding wrapper → firstElementChild is content column → firstElementChild is prose wrapper
     const outer = container.firstChild as HTMLElement;
-    const contentCol = outer.lastElementChild as HTMLElement;
+    const paddingWrapper = outer.lastElementChild as HTMLElement;
+    const contentCol = paddingWrapper.firstElementChild as HTMLElement;
     const proseWrapper = contentCol.firstElementChild as HTMLElement;
     expect(proseWrapper.style.fontSize).toBe("var(--font-size-doc-base)");
     expect(proseWrapper.style.lineHeight).toBe("1.7");
@@ -159,7 +167,7 @@ describe("DocumentViewer", () => {
   it("empty state uses design system tokens matching WelcomeScreen", () => {
     const { container } = render(<DocumentViewer />);
     const outer = container.firstChild as HTMLElement;
-    expect(outer.style.backgroundColor).toBe("var(--color-bg-app)");
+    expect(outer.style.backgroundColor).toBe("var(--color-bg-base)");
     const text = screen.getByText("Select a document from the sidebar");
     expect(text.style.color).toBe("var(--color-text-secondary)");
     expect(text.style.fontSize).toBe("var(--font-size-ui-lg)");


### PR DESCRIPTION
## Summary

- **DocumentViewer**: fix empty-state bg token (`--color-bg-app` → `--color-bg-base`), split `maxWidth`/`paddingInline` into nested elements so reading column is the intended 680px (not 616px), add `paddingBlock: var(--space-6)` for top/bottom breathing room
- **Dialog**: fix footer padding (`--padding-panel` 20px → `--space-4` 16px per spec)
- **SettingsPanel**: fix padding to `px-[--padding-content] pt-[--space-6]`, replace raw `<input>` with `<Input>` primitive (gains hover state, removes ~6 lines of duplicated Tailwind)
- **Button**: add active/pressed state per variant — primary `oklch(41%)`, secondary `--color-bg-overlay`, ghost `--color-bg-hover`, destructive `oklch(54%)`
- **TitleBar**: disable unwired back/forward/share buttons, give Section 3 fixed width (80px) for optical centering
- **app.css**: add `transition` to `.context-menu-item`, add `font-family: var(--font-ui)` to `:root`

## Test Plan

- [x] All 353 tests pass
- [x] Build succeeds (`npm run build`)
- [x] Only in-scope files modified (6 source + 1 test)
- [ ] DocumentViewer reading column is 680px wide (inspect element)
- [ ] Document content has breathing room at top after frontmatter bar
- [ ] Dialog footer padding visually tighter than body padding
- [ ] Button shows darker bg on mousedown/click across all 4 variants
- [ ] TitleBar back/forward/share buttons appear disabled (dimmed, no pointer)
- [ ] Title "Episteme" appears optically centered
- [ ] Context menu items animate smoothly on hover/keyboard navigation
- [ ] All UI text renders in Inter Variable font

🤖 Generated with [Claude Code](https://claude.com/claude-code)