### PR TITLE
chore: token hygiene — hardcoded values to tokens, a11y polish

### DIFF
--- a/src/components/CreateNewDialog.tsx
+++ b/src/components/CreateNewDialog.tsx
@@ -172,7 +172,7 @@ export function CreateNewDialog({
                 style={{
                   display: "flex",
                   alignItems: "center",
-                  gap: 12,
+                  gap: "var(--space-3)",
                   width: "100%",
                   padding: "var(--space-2) var(--space-3)",
                   border: "none",

--- a/src/components/DocumentViewer.tsx
+++ b/src/components/DocumentViewer.tsx
@@ -128,6 +128,7 @@ export function DocumentViewer() {
       <div style={{ paddingInline: "var(--padding-content)", paddingBlock: "var(--space-6)" }}>
         <div className="mx-auto" style={{ maxWidth: "var(--doc-content-width)" }}>
           {content !== null && (
+            // matches --font-size-doc-base line-height per spec
             <div style={{ fontSize: "var(--font-size-doc-base)", lineHeight: "1.7" }}>
               <MarkdownRenderer content={content} onLinkClick={handleLinkClick} />
             </div>

--- a/src/components/FileTree.tsx
+++ b/src/components/FileTree.tsx
@@ -147,7 +147,7 @@ export function FileTree() {
 
   if (nodes.length === 0) {
     return (
-      <p className="text-(--color-text-tertiary) text-[length:var(--font-size-ui-sm)] text-center py-8">
+      <p className="text-(--color-text-tertiary) text-[length:var(--font-size-ui-sm)] text-center py-[var(--space-8)]">
         No markdown files found
       </p>
     );

--- a/src/components/FileTreeItem.tsx
+++ b/src/components/FileTreeItem.tsx
@@ -31,6 +31,7 @@ export function FileTreeItem({
   onToggle,
   onSelect,
 }: FileTreeItemProps) {
+  // --space-3 (12px) base + --space-4 (16px) per depth level
   const paddingLeft = 12 + depth * 16;
 
   const handleClick = () => {

--- a/src/components/FrontmatterBar.tsx
+++ b/src/components/FrontmatterBar.tsx
@@ -24,8 +24,8 @@ function formatValue(value: unknown): string {
   return String(value);
 }
 
-const PAIR_GAP_PX = 24; // --space-6
-const BADGE_RESERVE_PX = 80; // badge width estimate for first-pass calculation
+const PAIR_GAP_PX = 24; // mirrors --space-6 (24px) — used in JS layout math
+const BADGE_RESERVE_PX = 80; // estimated badge width for first-pass overflow calculation
 
 export function calculateVisibleCount(
   containerWidth: number,

--- a/src/components/SettingsNav.tsx
+++ b/src/components/SettingsNav.tsx
@@ -14,7 +14,7 @@ export function SettingsNav() {
       <button
         onClick={closeSettings}
         aria-label="Back to app"
-        className="flex items-center gap-[var(--space-2)] px-[var(--space-2)] h-[var(--height-nav-item)] w-full text-[length:var(--font-size-ui-base)] text-(--color-text-tertiary) hover:text-(--color-text-primary) transition-colors duration-(--duration-fast) focus-ring"
+        className="flex items-center gap-[var(--space-2)] px-[var(--space-2)] h-[var(--height-nav-item)] w-full text-[length:var(--font-size-ui-base)] text-(--color-text-tertiary) hover:bg-(--color-bg-subtle) hover:text-(--color-text-primary) transition-colors duration-(--duration-fast) focus-ring"
       >
         <ChevronLeft size={16} />
         Back to app

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -29,10 +29,6 @@ function AwsProfileSetting({ id, label }: { id: string; label: string }) {
       .catch(() => {});
   }, []);
 
-  useEffect(() => {
-    inputRef.current?.focus();
-  }, []);
-
   const handleChange = (value: string) => {
     if (!prefsLoaded) return;
     setAwsProfile(value);

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -18,7 +18,7 @@ export function Sidebar({ children }: SidebarProps) {
 
   return (
     <aside className="w-[var(--width-sidebar)] h-full bg-(--color-bg-app) shrink-0 flex flex-col">
-      <div className="flex-1 overflow-y-auto py-2">
+      <div className="flex-1 overflow-y-auto py-[var(--space-2)]">
         {settingsOpen ? (
           <SettingsNav />
         ) : (
@@ -26,7 +26,7 @@ export function Sidebar({ children }: SidebarProps) {
             {folderName && (
               <div
                 data-testid="folder-header"
-                className="px-3 py-2 flex items-center justify-between border-b border-(--color-border-subtle) shrink-0 cursor-pointer hover:bg-(--color-bg-subtle) rounded"
+                className="px-[var(--space-3)] py-[var(--space-2)] flex items-center justify-between border-b border-(--color-border-subtle) shrink-0 cursor-pointer hover:bg-(--color-bg-subtle) rounded"
                 onClick={() => openFolder()}
               >
                 <button

--- a/src/components/WelcomeScreen.tsx
+++ b/src/components/WelcomeScreen.tsx
@@ -18,18 +18,18 @@ export function WelcomeScreen() {
           Episteme
         </h1>
         <p
-          className="mt-2"
+          className="mt-[var(--space-2)]"
           style={{ color: "var(--color-text-secondary)" }}
         >
           Open a folder to get started
         </p>
-        <Button variant="primary" onClick={openFolder} className="mt-6">
+        <Button variant="primary" onClick={openFolder} className="mt-[var(--space-6)]">
           <FolderOpen size={16} />
           Open Folder
         </Button>
         {error && (
           <p
-            className="mt-4 text-sm"
+            className="mt-[var(--space-4)] text-[length:var(--font-size-ui-sm)]"
             style={{ color: "var(--color-state-danger)" }}
           >
             Could not open folder. Please check permissions and try again.

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -39,6 +39,7 @@ const baseStyle: React.CSSProperties = {
   fontWeight: 500,
   borderRadius: "var(--radius-sm)",
   whiteSpace: "nowrap",
+  lineHeight: 1,
 };
 
 export function Badge({ variant = "neutral", children }: BadgeProps) {

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -75,7 +75,7 @@ export function Button({
     display: "inline-flex",
     alignItems: "center",
     justifyContent: "center",
-    gap: "8px",
+    gap: "var(--space-2)",
     height,
     padding: isIconOnly ? "0" : "var(--padding-control)",
     width: isIconOnly ? height : undefined,

--- a/src/components/ui/ContextMenu.tsx
+++ b/src/components/ui/ContextMenu.tsx
@@ -46,7 +46,7 @@ export function ContextMenuItem({
         display: "flex",
         alignItems: "center",
         height: "var(--height-control-base)",
-        padding: "0 8px",
+        padding: "0 var(--space-2)",
         fontSize: "var(--font-size-ui-base)",
         color: destructive
           ? "var(--color-state-danger)"
@@ -84,7 +84,7 @@ export function ContextMenuLabel({ children }: { children: React.ReactNode }) {
         fontWeight: 500,
         textTransform: "uppercase",
         color: "var(--color-text-quaternary)",
-        padding: "var(--space-1) 8px",
+        padding: "var(--space-1) var(--space-2)",
       }}
     >
       {children}

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -47,6 +47,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
         {...rest}
         ref={ref}
         disabled={disabled}
+        aria-invalid={error || undefined}
         data-ui-input=""
         style={baseStyle}
         onMouseEnter={(e) => {

--- a/src/components/ui/Popover.tsx
+++ b/src/components/ui/Popover.tsx
@@ -14,7 +14,7 @@ export function PopoverContent({
     <RadixPopover.Portal>
       <RadixPopover.Content
         className="overlay-surface"
-        sideOffset={props.sideOffset ?? 4}
+        sideOffset={props.sideOffset ?? 4} // 4px = --space-1; Radix expects a number prop
         {...props}
         style={{
           backgroundColor: "var(--color-bg-overlay)",


### PR DESCRIPTION
## Summary

Final PR in the 4-part design system audit. All changes are mechanical:

- **Hardcoded values → tokens**: `gap: "8px"` → `var(--space-2)`, `padding: "0 8px"` → `0 var(--space-2)`, `gap: 12` → `var(--space-3)` across Button, ContextMenu, CreateNewDialog
- **Tailwind defaults → token refs**: `py-2` → `py-[var(--space-2)]`, `mt-6` → `mt-[var(--space-6)]`, `text-sm` → `text-[length:var(--font-size-ui-sm)]` across Sidebar, WelcomeScreen, FileTree
- **Magic number comments**: Added explanatory comments on necessary hardcoded values in FrontmatterBar, DocumentViewer, FileTreeItem, Popover
- **A11y polish**: SettingsNav back button hover bg, Input `aria-invalid`, Badge `lineHeight: 1`, remove SettingsPanel auto-focus

14 files changed, net zero lines (18 insertions, 18 deletions).

## Test Plan

- [x] All 353 tests pass
- [x] Build succeeds
- [x] Net zero line change — pure mechanical cleanup
- [ ] Visual spot-check: no spacing regressions (token values match the replaced hardcoded values)

🤖 Generated with [Claude Code](https://claude.com/claude-code)