### PR TITLE
fix: correct git-cliff asset filename (remove v prefix)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,8 +96,8 @@ jobs:
 
       - name: Install git-cliff
         run: |
-          curl -L "https://github.com/orhun/git-cliff/releases/download/v2.4.0/git-cliff-v2.4.0-x86_64-unknown-linux-musl.tar.gz" | tar xz
-          sudo mv git-cliff-v2.4.0/git-cliff /usr/local/bin/git-cliff
+          curl -L "https://github.com/orhun/git-cliff/releases/download/v2.4.0/git-cliff-2.4.0-x86_64-unknown-linux-musl.tar.gz" | tar xz
+          sudo mv git-cliff-2.4.0/git-cliff /usr/local/bin/git-cliff
 
       - name: Generate changelog
         run: git cliff --config cliff.toml --latest --strip header > CHANGELOG_LATEST.md


### PR DESCRIPTION
## Summary

- Asset name is `git-cliff-2.4.0-*`, not `git-cliff-v2.4.0-*` — the `v` prefix appears only in the git tag, not the filename
- Fixes the third pipeline failure for `v0.0.1-test`

## Test plan
- [ ] Merge and retag `v0.0.1-test` to trigger pipeline
- [ ] Verify publish job installs git-cliff and generates `CHANGELOG_LATEST.md` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)