### PR TITLE
fix: grant contents:write permission to publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,8 @@ jobs:
   publish:
     needs: build
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

- `softprops/action-gh-release` was getting 403 because `GITHUB_TOKEN` lacked write permission
- Added `permissions: contents: write` to the `publish` job

## Test plan
- [ ] Merge and retag `v0.0.1-test`
- [ ] Verify publish job creates draft release successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)