### PR TITLE
feat: rename release assets to human-readable names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,19 +145,27 @@ jobs:
           echo "Generated latest.json:"
           cat latest.json
 
+      - name: Rename installers
+        run: |
+          for f in artifacts/*aarch64-apple-darwin*.dmg; do [ -f "$f" ] && mv "$f" "artifacts/Episteme - Mac (M1+).dmg"; done
+          for f in artifacts/*x86_64-apple-darwin*.dmg; do [ -f "$f" ] && mv "$f" "artifacts/Episteme - Mac (Intel).dmg"; done
+          for f in artifacts/*.AppImage; do [ -f "$f" ] && mv "$f" "artifacts/Episteme - Linux (x64).AppImage"; done
+          for f in artifacts/*_en-US.msi; do [ -f "$f" ] && mv "$f" "artifacts/Episteme - Windows (x64).msi"; done
+
       - name: Create draft release
         uses: softprops/action-gh-release@v2
         with:
           draft: true
           body_path: CHANGELOG_LATEST.md
           files: |
-            artifacts/**/*.dmg
+            artifacts/Episteme - Mac (M1+).dmg
+            artifacts/Episteme - Mac (Intel).dmg
+            artifacts/Episteme - Linux (x64).AppImage
+            artifacts/Episteme - Windows (x64).msi
             artifacts/**/*.app.tar.gz
             artifacts/**/*.app.tar.gz.sig
-            artifacts/**/*.msi
             artifacts/**/*.msi.zip
             artifacts/**/*.msi.zip.sig
-            artifacts/**/*.AppImage
             artifacts/**/*.AppImage.tar.gz
             artifacts/**/*.AppImage.tar.gz.sig
             latest.json


### PR DESCRIPTION
## Summary

- Adds a rename step in the publish job before uploading to GitHub Release
- Updater payloads (`.app.tar.gz`, `latest.json`) keep their original names since they're referenced by URL in `latest.json`

**Before:** `Episteme_0.1.0_aarch64.dmg`, `Episteme_0.1.0_x64_en-US.msi`, etc.
**After:** `Episteme - Mac (M1+).dmg`, `Episteme - Windows (x64).msi`, etc.

## Test plan
- [ ] Merge and retag `v0.0.1-test` to confirm asset names in draft release

🤖 Generated with [Claude Code](https://claude.com/claude-code)