### PR TITLE
fix: window dragging broken in overlay title bar

### DIFF
--- a/.eng-docs/wiki/design-system.md
+++ b/.eng-docs/wiki/design-system.md
@@ -294,11 +294,28 @@ The title bar is a full-width strip rendered in `App.tsx` above all panels. It i
 - **Section 3 (actions)** — fixed width, right-aligned global action buttons (Share, New Document).
 
 **Tokens and styling:**
-- **Height**: `--height-titlebar` (40px)
+- **Height**: `--height-titlebar` (32px)
 - **Background**: `--color-bg-app`
 - **Bottom border**: `1px solid --color-border-subtle`
-- **Drag region**: root element (`-webkit-app-region: drag`); all interactive controls override to `-webkit-app-region: no-drag`
-- **Traffic lights no-drag zone**: left 70px of Section 1 (`-webkit-app-region: no-drag`)
+- **Drag region**: Section 2 div carries `data-tauri-drag-region`. Its decorative children (icon, label) use `pointerEvents: "none"` so clicks on them fall through to Section 2 rather than landing on those elements directly.
+- **No-drag zones**: `className="titlebar-no-drag"` on the traffic lights placeholder and action buttons section.
+- **Root div**: `userSelect: "none"` via inline style.
+
+**Important: how Tauri drag regions work on macOS**
+
+Tauri's drag JS (`drag.js`) checks `e.target.getAttribute('data-tauri-drag-region')` — the **direct** event target, not any ancestor. Placing the attribute on a container whose children cover its entire surface does nothing; the children will always be the event target and they don't carry the attribute.
+
+Two rules to follow:
+1. Put `data-tauri-drag-region` on the specific element that should be the hit target — the div that the pointer lands on, not a wrapper around it.
+2. If that element has decorative (non-interactive) children that would intercept clicks, set `pointerEvents: "none"` on those children.
+
+**Important: Lightning CSS and `-webkit-app-region`**
+
+Tailwind v4 uses Lightning CSS, which strips `-webkit-app-region` as non-standard. Additionally, `-webkit-app-region` set on an ancestor does not appear to propagate to WKWebView hit-testing — the wry project's own examples use only the JS approach for macOS drag.
+
+The `index.html` `<style>` block defines `.titlebar-no-drag { -webkit-app-region: no-drag; }` as belt-and-suspenders for no-drag zones (bypasses Lightning CSS). `src-tauri/capabilities/default.json` must include `"core:window:allow-start-dragging"` for the double-click-to-maximize IPC call.
+
+- **Traffic lights no-drag zone**: left 70px of Section 1, `className="titlebar-no-drag"`
 
 #### Windows (Phase 2)
 

--- a/index.html
+++ b/index.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Episteme</title>
+    <!-- Tailwind v4 uses Lightning CSS which strips -webkit-app-region as non-standard.
+         Injecting here bypasses the CSS pipeline entirely. -->
+    <style>
+      [data-tauri-drag-region] { -webkit-app-region: drag; }
+      .titlebar-no-drag         { -webkit-app-region: no-drag; }
+    </style>
   </head>
   <body>
     <div id="root"></div>

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,6 +7,7 @@
   ],
   "permissions": [
     "core:default",
+    "core:window:allow-start-dragging",
     "dialog:default",
     "dialog:allow-open",
     "shell:allow-open"

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -14,7 +14,6 @@ export function TitleBar({ folderPath, onStartAuthoring }: TitleBarProps) {
   return (
     <>
       <div
-        data-tauri-drag-region
         style={{
           height: "var(--height-titlebar)",
           background: "var(--color-bg-app)",
@@ -22,10 +21,12 @@ export function TitleBar({ folderPath, onStartAuthoring }: TitleBarProps) {
           display: "flex",
           alignItems: "center",
           flexShrink: 0,
+          userSelect: "none",
         }}
       >
         {/* Section 1: sidebar — width tracks --width-sidebar via CSS variable */}
         <div
+          data-tauri-drag-region
           style={{
             width: "var(--width-sidebar)",
             height: "100%",
@@ -49,8 +50,12 @@ export function TitleBar({ folderPath, onStartAuthoring }: TitleBarProps) {
           </Button>
         </div>
 
-        {/* Section 2: title — flex:1, centered icon + text, entire section is drag region */}
+        {/* Section 2: title — flex:1, centered icon + text, entire section is drag region.
+            data-tauri-drag-region is on this div (not the root) so that drag.js sees it as
+            e.target when the section itself is clicked. Children use pointerEvents:none so
+            clicks on the icon/label fall through to this div rather than targeting them. */}
         <div
+          data-tauri-drag-region
           style={{
             flex: 1,
             height: "100%",
@@ -60,13 +65,14 @@ export function TitleBar({ folderPath, onStartAuthoring }: TitleBarProps) {
             gap: "var(--space-2)",
           }}
         >
-          <Aperture size={14} style={{ color: "var(--color-text-tertiary)", flexShrink: 0 }} />
+          <Aperture size={14} style={{ color: "var(--color-text-tertiary)", flexShrink: 0, pointerEvents: "none" }} />
           <span
             style={{
               fontFamily: "var(--font-ui)",
               fontSize: "var(--font-size-ui-base)",
               fontWeight: 500,
               color: "var(--color-text-secondary)",
+              pointerEvents: "none",
             }}
           >
             Episteme


### PR DESCRIPTION
Fixes #45.

## Root causes

**1. `data-tauri-drag-region` on a container never fires**
`drag.js` checks `e.target.getAttribute('data-tauri-drag-region')` — the direct event target only, not ancestors. With the attribute on the root wrapper, every click lands on a child element and the check always fails. Fixed by moving the attribute to the specific divs that should be hit targets (Sections 1 and 2), and adding `pointerEvents: "none"` to decorative children in Section 2 so clicks fall through to the div.

**2. Lightning CSS strips `-webkit-app-region`**
Tailwind v4 uses Lightning CSS, which removes `-webkit-app-region` as a non-standard property — confirmed by inspecting compiled CSS output. Defined both drag/no-drag rules in a `<style>` block in `index.html`, which bypasses the pipeline entirely.

**3. Missing `allow-start-dragging` capability**
`startDragging()` (used for double-click-to-maximize) requires `core:window:allow-start-dragging` in capabilities. It is not included in `core:window:default`. Added explicitly.

## Also fixed
- `titlebar-no-drag` was referenced as a `className` in `TitleBar.tsx` but never defined in CSS — now defined in `index.html`.
- `--height-titlebar` documented as 40px in `design-system.md`; corrected to 32px.
- Updated `design-system.md` with the two rules for future drag region work.

## Test plan
- [ ] Drag window by clicking and holding in the title bar center (Section 2 — text/icon area)
- [ ] Drag window by clicking empty space in Section 1 (sidebar-width strip)
- [ ] Traffic light buttons respond normally; do not trigger drag
- [ ] Nav back/forward buttons respond normally; do not trigger drag
- [ ] Action buttons (Share, New Document) respond normally
- [ ] Double-click title bar maximizes/restores window
- [ ] 366 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)