### PR TITLE
docs: mark keyboard-shortcuts v1 spec as superseded by v2

### DIFF
--- a/.eng-docs/specs/feature-keyboard-shortcuts.md
+++ b/.eng-docs/specs/feature-keyboard-shortcuts.md
@@ -1,11 +1,11 @@
 ---
 created: 2026-03-14
 last_updated: 2026-03-15
-status: complete
+status: superseded
 issue: 26
 specced_by: markdstafford
 implemented_by: markdstafford
-superseded_by: null
+superseded_by: feature-keyboard-shortcuts-v2.md
 ---
 
 # Keyboard shortcuts


### PR DESCRIPTION
## Summary
- Updates `feature-keyboard-shortcuts.md` frontmatter: `status: superseded`, `superseded_by: feature-keyboard-shortcuts-v2.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)