### PR TITLE
docs: ADR-013 — document content boundary

### DIFF
--- a/.eng-docs/adrs/adr-013-document-contents.md
+++ b/.eng-docs/adrs/adr-013-document-contents.md
@@ -6,7 +6,7 @@ decided_by: markdstafford
 superseded_by: null
 ---
 
-# ADR 013: Document Content Boundary
+# ADR 013: Document Contents
 
 ## Status
 


### PR DESCRIPTION
## Summary

- Adds ADR-013 establishing what lives in the markdown file vs. external storage
- Defines the litmus test: *should this change be obvious in git history?*
- Document prose, frontmatter, and footnotes belong in the file; comments, reactions, sharing, and other user interactions belong in external storage

## Test plan

- [ ] Review ADR content and confirm it accurately reflects the design discussion

🤖 Generated with [Claude Code](https://claude.com/claude-code)