### PR TITLE
feat(comments): log comment AI requests to disk for diagnostics

### DIFF
--- a/src-tauri/src/commands/comment_ai_log.rs
+++ b/src-tauri/src/commands/comment_ai_log.rs
@@ -1,0 +1,46 @@
+use serde_json::Value;
+use tauri::Manager;
+
+pub struct CommentAiLogLock(pub std::sync::Mutex<()>);
+
+const MAX_ENTRIES: usize = 100;
+
+fn log_path(app: &tauri::AppHandle) -> Result<std::path::PathBuf, String> {
+    let app_data = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to get app data dir: {}", e))?;
+    Ok(app_data.join("comment-ai-log.json"))
+}
+
+#[tauri::command]
+pub async fn log_comment_ai(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, CommentAiLogLock>,
+    entry: Value,
+) -> Result<(), String> {
+    let path = log_path(&app)?;
+    let _guard = state.0.lock().map_err(|e| format!("Lock error: {}", e))?;
+
+    let mut entries: Vec<Value> = if path.exists() {
+        let contents = std::fs::read_to_string(&path).unwrap_or_default();
+        serde_json::from_str(&contents).unwrap_or_default()
+    } else {
+        vec![]
+    };
+
+    entries.push(entry);
+
+    if entries.len() > MAX_ENTRIES {
+        let drain = entries.len() - MAX_ENTRIES;
+        entries.drain(0..drain);
+    }
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+
+    let json = serde_json::to_string_pretty(&entries)
+        .map_err(|e| format!("Serialize error: {}", e))?;
+    std::fs::write(&path, json).map_err(|e| format!("Failed to write log: {}", e))
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod ai;
+pub mod comment_ai_log;
 pub mod comments;
 pub mod files;
 pub mod folder;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -57,6 +57,7 @@ pub fn run() {
       commands::comments::cancel_queued_comment,
       commands::comments::load_queued_comments,
       commands::comments::update_thread_anchors,
+      commands::comment_ai_log::log_comment_ai,
     ])
     .setup(|app| {
       if cfg!(debug_assertions) {
@@ -93,6 +94,7 @@ pub fn run() {
 
       app.manage(commands::updater::PendingUpdate(std::sync::Mutex::new(None)));
       app.manage(commands::sessions::SessionsLock(std::sync::Mutex::new(())));
+      app.manage(commands::comment_ai_log::CommentAiLogLock(std::sync::Mutex::new(())));
       app.manage(ManifestState(std::sync::Mutex::new(None)));
       app.manage(WatcherState(std::sync::Mutex::new(None)));
       app.manage(db::DbState(std::sync::Mutex::new(None)));

--- a/src/lib/commentAi.ts
+++ b/src/lib/commentAi.ts
@@ -1,5 +1,11 @@
 import { invoke } from "@tauri-apps/api/core";
 
+function logCommentAi(entry: Record<string, unknown>): void {
+  invoke("log_comment_ai", {
+    entry: { ts: new Date().toISOString(), ...entry },
+  }).catch(() => {});
+}
+
 // ── Auth error detection ──────────────────────────────────────────────────────
 
 const AUTH_ERROR_PATTERNS = [
@@ -132,9 +138,30 @@ export async function vetComment(params: VetParams): Promise<VetResult> {
   try {
     response = await callAi(vetPrompt, userMsg, params.awsProfile);
   } catch (e) {
+    logCommentAi({
+      call: "vet_comment",
+      concern: params.concern,
+      quoted_text: params.quotedText,
+      surrounding_context: params.surroundingContext ?? "",
+      doc_content: params.docContent,
+      related_docs: params.relatedDocs,
+      response: null,
+      error: String(e),
+    });
     if (isAuthError(String(e))) throw e;
     return { type: "proceed" };
   }
+
+  logCommentAi({
+    call: "vet_comment",
+    concern: params.concern,
+    quoted_text: params.quotedText,
+    surrounding_context: params.surroundingContext ?? "",
+    doc_content: params.docContent,
+    related_docs: params.relatedDocs,
+    response,
+    error: null,
+  });
 
   const parsed = extractJson(response);
   if (!parsed || typeof parsed !== "object") return { type: "proceed" };
@@ -171,8 +198,26 @@ export async function suggestCommentText(params: {
       userMsg,
       params.awsProfile,
     );
+    logCommentAi({
+      call: "suggest_comment_text",
+      concern: params.concern,
+      quoted_text: params.quotedText,
+      surrounding_context: params.surroundingContext,
+      doc_content: params.docContent,
+      response: result,
+      error: null,
+    });
     return result.trim() || params.concern;
-  } catch {
+  } catch (e) {
+    logCommentAi({
+      call: "suggest_comment_text",
+      concern: params.concern,
+      quoted_text: params.quotedText,
+      surrounding_context: params.surroundingContext,
+      doc_content: params.docContent,
+      response: null,
+      error: String(e),
+    });
     return params.concern;
   }
 }
@@ -205,8 +250,26 @@ export async function enhanceCommentBody(params: {
       callAi(ENHANCE_SYSTEM_PROMPT, parts.join("\n\n"), params.awsProfile),
       new Promise<null>((resolve) => setTimeout(() => resolve(null), timeoutMs)),
     ]);
+    logCommentAi({
+      call: "enhance_comment_body",
+      body: params.body,
+      quoted_text: params.quotedText ?? "",
+      doc_content: params.docContent ?? "",
+      thread_comments: params.threadComments ?? [],
+      response: typeof result === "string" ? result : null,
+      error: null,
+    });
     return typeof result === "string" ? result.trim() : null;
-  } catch {
+  } catch (e) {
+    logCommentAi({
+      call: "enhance_comment_body",
+      body: params.body,
+      quoted_text: params.quotedText ?? "",
+      doc_content: params.docContent ?? "",
+      thread_comments: params.threadComments ?? [],
+      response: null,
+      error: String(e),
+    });
     return null;
   }
 }

--- a/src/lib/commentAiFix.ts
+++ b/src/lib/commentAiFix.ts
@@ -2,6 +2,12 @@ import { invoke } from "@tauri-apps/api/core";
 import type { Thread } from "@/types/comments";
 import { extractJson } from "@/lib/commentAi";
 
+function logCommentAi(entry: Record<string, unknown>): void {
+  invoke("log_comment_ai", {
+    entry: { ts: new Date().toISOString(), ...entry },
+  }).catch(() => {});
+}
+
 const FIX_SYSTEM_PROMPT = `You are helping a document author address a reviewer's comment.
 Given the comment thread and document, propose a specific, minimal document edit.
 Return JSON only: {"fix":"<replacement text>","originalText":"<text to replace>","reply":"<summary for thread>"}
@@ -28,12 +34,28 @@ export async function suggestFix(params: {
       awsProfile: params.awsProfile,
     });
 
+    logCommentAi({
+      call: "suggest_fix",
+      quoted_text: params.thread.quoted_text,
+      doc_content: params.docContent,
+      thread_comments: params.thread.comments.map(c => ({ author: c.author, body: c.body })),
+      response,
+      error: null,
+    });
     const parsed = extractJson(response);
     if (!parsed || typeof parsed !== "object") return null;
     const p = parsed as Record<string, unknown>;
     if (p.fix && p.originalText && p.reply) return p as unknown as { fix: string; originalText: string; reply: string };
     return null;
-  } catch {
+  } catch (e) {
+    logCommentAi({
+      call: "suggest_fix",
+      quoted_text: params.thread.quoted_text,
+      doc_content: params.docContent,
+      thread_comments: params.thread.comments.map(c => ({ author: c.author, body: c.body })),
+      response: null,
+      error: String(e),
+    });
     return null;
   }
 }


### PR DESCRIPTION
## Summary

- Adds structured logging for all comment AI calls (`vet_comment`, `suggest_comment_text`, `enhance_comment_body`, `suggest_fix`) to `comment-ai-log.json` in the app data dir
- Each entry captures exact structured inputs — `quoted_text`, `doc_content`, `surrounding_context`, `thread_comments` — alongside the response, so missing context is immediately visible
- Keeps last 100 entries; separate from `sessions.json` and invisible to the session history view
- New Rust command `log_comment_ai` with its own mutex, following the sessions pattern

## Test plan

- [ ] Add a comment — verify entry appears in `~/Library/Application Support/com.episteme.app/comment-ai-log.json` with populated `doc_content`
- [ ] Reply to a thread — verify `enhance_comment_body` entry appears with `thread_comments` and `quoted_text`

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)